### PR TITLE
Activate consumable effects for stat calculation

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## Additions
 - Add ability to change plot plane for vertical dispersion chart.
+- Allow to include consumable effects in ship statistics (#141)
 
 ## Changes
 - The gamedata updater no longer downloads data that is not supported by the current application version. 

--- a/WoWsShipBuilder.Core/BuildCreator/IBuildStorable.cs
+++ b/WoWsShipBuilder.Core/BuildCreator/IBuildStorable.cs
@@ -1,11 +1,18 @@
 ﻿using System.Collections.Generic;
 
-namespace WoWsShipBuilder.Core.BuildCreator
-{
-    public interface IBuildStorable
-    {
-        void LoadBuild(IEnumerable<string> storedData);
+namespace WoWsShipBuilder.Core.BuildCreator;
 
-        List<string> SaveBuild();
-    }
+public interface IBuildStorable
+{
+    /// <summary>
+    /// Loads data from a stored build into the current instance.
+    /// </summary>
+    /// <param name="storedData">An <see cref="IEnumerable{T}"/> containing stored build data.</param>
+    void LoadBuild(IEnumerable<string> storedData);
+
+    /// <summary>
+    /// Saves data from the current instance for a build.
+    /// </summary>
+    /// <returns>A list containing the new build data.</returns>
+    List<string> SaveBuild();
 }

--- a/WoWsShipBuilder.Core/DataContainers/Aircraft/CvAircraftDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Aircraft/CvAircraftDataContainer.cs
@@ -288,7 +288,7 @@ namespace WoWsShipBuilder.Core.DataContainers
             List<ConsumableDataContainer> consumables = new();
             foreach (var consumable in plane.AircraftConsumable ?? new List<AircraftConsumable>())
             {
-                var consumableDataContainer = await ConsumableDataContainer.FromTypeAndVariant(consumable.ConsumableName, consumable.ConsumableVariantName, consumable.Slot, modifiers, true, finalPlaneHp, 0);
+                var consumableDataContainer = await ConsumableDataContainer.FromTypeAndVariant(consumable, modifiers, true, finalPlaneHp, 0, appDataService);
                 consumables.Add(consumableDataContainer);
             }
 

--- a/WoWsShipBuilder.Core/DataContainers/Armament/MainBatteryDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Armament/MainBatteryDataContainer.cs
@@ -161,6 +161,8 @@ namespace WoWsShipBuilder.Core.DataContainers
             var rangeModifiers = modifiers.FindModifiers("GMMaxDist");
             decimal gunRange = mainBattery.MaxRange * suoConfiguration.MaxRangeModifier;
             decimal range = rangeModifiers.Aggregate(gunRange, (current, modifier) => current * (decimal)modifier);
+            var consumableRangeModifiers = modifiers.FindModifiers("artilleryDistCoeff");
+            range = consumableRangeModifiers.Aggregate(range, (current, modifier) => current * (decimal)modifier);
 
             var talentRangeModifiers = modifiers.FindModifiers("talentMaxDistGM");
             range = talentRangeModifiers.Aggregate(range, (current, modifier) => current * (decimal)modifier) / 1000;

--- a/WoWsShipBuilder.Core/DataContainers/Ship/AntiAirDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Ship/AntiAirDataContainer.cs
@@ -43,22 +43,11 @@ namespace WoWsShipBuilder.Core.DataContainers
             }
 
             // var flakBonus = 0;
-            decimal flakDamageBonus = 1;
-            decimal constantDamageBonus = 1;
+            decimal flakDamageBonus = modifiers.FindModifiers("AABubbleDamage").Aggregate(1M, (current, value) => current * (decimal)value);
+            flakDamageBonus = modifiers.FindModifiers("bubbleDamageMultiplier").Aggregate(flakDamageBonus, (current, modifier) => current * (decimal)modifier);
 
-            int flakDamageBonusIndex = modifiers.FindModifierIndex("AABubbleDamage");
-            if (flakDamageBonusIndex > -1)
-            {
-                List<float> modifiersValues = modifiers.FindModifiers("AABubbleDamage").ToList();
-                flakDamageBonus = modifiersValues.Aggregate(flakDamageBonus, (current, value) => current * (decimal)value);
-            }
-
-            int constantDamageBonusIndex = modifiers.FindModifierIndex("AAAuraDamage");
-            if (constantDamageBonusIndex > -1)
-            {
-                List<float> modifiersValues = modifiers.FindModifiers("AAAuraDamage").ToList();
-                constantDamageBonus = modifiersValues.Aggregate(constantDamageBonus, (current, value) => current * (decimal)value);
-            }
+            decimal constantDamageBonus = modifiers.FindModifiers("AAAuraDamage").Aggregate(1M, (current, value) => current * (decimal)value);
+            constantDamageBonus = modifiers.FindModifiers("areaDamageMultiplier").Aggregate(constantDamageBonus, (current, value) => current * (decimal)value);
 
             IEnumerable<float> constantDamageBonusModifiers = modifiers.FindModifiers("lastChanceReloadCoefficient");
             constantDamageBonus = Math.Round(constantDamageBonusModifiers.Aggregate(constantDamageBonus, (current, arModifier) => current * (1 + ((decimal)arModifier / 100))), 2);

--- a/WoWsShipBuilder.Core/DataContainers/Ship/ManeuverabilityDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Ship/ManeuverabilityDataContainer.cs
@@ -52,8 +52,8 @@ public partial record ManeuverabilityDataContainer : DataContainerBase
 
         var manoeuvrability = new ManeuverabilityDataContainer
         {
-            FullPowerBackward = engine.BackwardEngineUpTime * fullPowerBackwardModifier / Constants.TimeScale,
-            FullPowerForward = engine.ForwardEngineUpTime * fullPowerForwardModifier / Constants.TimeScale,
+            FullPowerBackward = Math.Round(engine.BackwardEngineUpTime * fullPowerBackwardModifier / Constants.TimeScale),
+            FullPowerForward = Math.Round(engine.ForwardEngineUpTime * fullPowerForwardModifier / Constants.TimeScale),
             ManeuverabilityMaxSpeed = Math.Round(hull.MaxSpeed * (engine.SpeedCoef + 1) * maxSpeedModifier, 2),
             ManeuverabilityRudderShiftTime = Math.Round((hull.RudderTime * rudderShiftModifier) / 1.305M, 2),
             ManeuverabilityTurningCircle = hull.TurningRadius,

--- a/WoWsShipBuilder.Core/DataContainers/Ship/SurvivabilityDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Ship/SurvivabilityDataContainer.cs
@@ -144,7 +144,7 @@ namespace WoWsShipBuilder.Core.DataContainers
                 FloodTotalDamage = Math.Round(floodTotalDamage),
             };
 
-            foreach (var location in shipHull.HitLocations)
+            foreach (var location in shipHull.HitLocations ?? new List<HitLocation>())
             {
                 switch (location.Name)
                 {

--- a/WoWsShipBuilder.Core/DataProvider/AppData.cs
+++ b/WoWsShipBuilder.Core/DataProvider/AppData.cs
@@ -1,118 +1,113 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
 using WoWsShipBuilder.Core.BuildCreator;
 using WoWsShipBuilder.Core.Settings;
 using WoWsShipBuilder.DataStructures;
 
-namespace WoWsShipBuilder.Core.DataProvider
+namespace WoWsShipBuilder.Core.DataProvider;
+
+/// <summary>
+/// The main storage for app data and settings at runtime.
+/// </summary>
+public static class AppData
 {
+    private static Nation? currentLoadedNation;
+
     /// <summary>
-    /// The main storage for app data and settings at runtime.
+    /// Gets or sets a value indicating whether application settings have been initialized.
     /// </summary>
-    public static class AppData
+    public static bool IsInitialized { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current data version name.
+    /// </summary>
+    public static string? DataVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ship dictionary for the currently selected nation.
+    /// </summary>
+    /// <seealso cref="CurrentLoadedNation"/>
+    public static Dictionary<string, Ship>? ShipDictionary { get; set; }
+
+    /// <summary>
+    /// Gets or sets the currently selected <see cref="Nation"/>.
+    /// When the nation is changed, the <see cref="ProjectileCache"/> and <see cref="AircraftCache"/> are automatically cleared.
+    /// </summary>
+    public static Nation? CurrentLoadedNation
     {
-        private static Nation? currentLoadedNation;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether application settings have been initialized.
-        /// </summary>
-        public static bool IsInitialized { get; set; }
-
-        /// <summary>
-        /// Gets or sets the current <see cref="AppSettings"/> for the application.
-        /// </summary>
-        // public static AppSettings Settings { get; set; } = new();
-
-        /// <summary>
-        /// Gets or sets the current data version name.
-        /// </summary>
-        public static string? DataVersion { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ship dictionary for the currently selected nation.
-        /// </summary>
-        /// <seealso cref="CurrentLoadedNation"/>
-        public static Dictionary<string, Ship>? ShipDictionary { get; set; }
-
-        /// <summary>
-        /// Gets or sets the currently selected <see cref="Nation"/>.
-        /// When the nation is changed, the <see cref="ProjectileCache"/> and <see cref="AircraftCache"/> are automatically cleared.
-        /// </summary>
-        public static Nation? CurrentLoadedNation
+        get => currentLoadedNation;
+        set
         {
-            get => currentLoadedNation;
-            set
+            if (value != currentLoadedNation)
             {
-                if (value != currentLoadedNation)
-                {
-                    ProjectileCache.Clear();
-                    AircraftCache.Clear();
-                }
-
-                currentLoadedNation = value;
+                ProjectileCache.Clear();
+                AircraftCache.Clear();
             }
+
+            currentLoadedNation = value;
         }
+    }
 
-        /// <summary>
-        /// Gets or sets the list of available consumables.
-        /// </summary>
-        public static Dictionary<string, Consumable>? ConsumableList { get; set; }
+    /// <summary>
+    /// Gets or sets the list of available consumables.
+    /// </summary>
+    public static Dictionary<string, Consumable>? ConsumableList { get; set; }
 
-        /// <summary>
-        /// Gets the projectile cache, mapping a nation to the actual projectile dictionary for that nation.
-        /// This property should not be accessed directly, use <see cref="DesktopAppDataService.GetProjectile"/> instead.
-        /// </summary>
-        /// <seealso cref="DesktopAppDataService.GetProjectile"/>
-        /// <seealso cref="DesktopAppDataService.GetProjectile{T}"/>
-        public static Dictionary<Nation, Dictionary<string, Projectile>> ProjectileCache { get; } = new();
+    /// <summary>
+    /// Gets the projectile cache, mapping a nation to the actual projectile dictionary for that nation.
+    /// This property should not be accessed directly, use <see cref="DesktopAppDataService.GetProjectile"/> instead.
+    /// </summary>
+    /// <seealso cref="DesktopAppDataService.GetProjectile"/>
+    /// <seealso cref="DesktopAppDataService.GetProjectile{T}"/>
+    public static Dictionary<Nation, Dictionary<string, Projectile>> ProjectileCache { get; } = new();
 
-        /// <summary>
-        /// Gets the aircraft cache, mapping a nation to the actual aircraft dictionary for that nation.
-        /// This property should not be accessed directly, use <see cref="DesktopAppDataService.GetAircraft"/> instead.
-        /// </summary>
-        /// <seealso cref="DesktopAppDataService.GetAircraft"/>
-        public static Dictionary<Nation, Dictionary<string, Aircraft>> AircraftCache { get; } = new();
+    /// <summary>
+    /// Gets the aircraft cache, mapping a nation to the actual aircraft dictionary for that nation.
+    /// This property should not be accessed directly, use <see cref="DesktopAppDataService.GetAircraft"/> instead.
+    /// </summary>
+    /// <seealso cref="DesktopAppDataService.GetAircraft"/>
+    public static ConcurrentDictionary<Nation, Dictionary<string, Aircraft>> AircraftCache { get; } = new();
 
-        public static Dictionary<Nation, Dictionary<string, Exterior>> ExteriorCache { get; } = new();
+    public static Dictionary<Nation, Dictionary<string, Exterior>> ExteriorCache { get; } = new();
 
-        public static Dictionary<Nation, Dictionary<string, Captain>> CaptainCache { get; } = new();
+    public static Dictionary<Nation, Dictionary<string, Captain>> CaptainCache { get; } = new();
 
-        public static Dictionary<string, Modernization> ModernizationCache { get; } = new();
+    public static Dictionary<string, Modernization> ModernizationCache { get; } = new();
 
-        /// <summary>
-        /// Gets or sets the list of <see cref="ShipSummary">ship summaries</see> that are currently available.
-        /// </summary>
-        public static List<ShipSummary>? ShipSummaryList { get; set; }
+    /// <summary>
+    /// Gets or sets the list of <see cref="ShipSummary">ship summaries</see> that are currently available.
+    /// </summary>
+    public static List<ShipSummary>? ShipSummaryList { get; set; }
 
-        /// <summary>
-        /// Gets or sets the list of the last used builds.
-        /// </summary>
-        public static List<Build> Builds { get; set; } = new();
+    /// <summary>
+    /// Gets or sets the list of the last used builds.
+    /// </summary>
+    public static List<Build> Builds { get; set; } = new();
 
 #if DEBUG
-        public static bool IsDebug => true;
+    public static bool IsDebug => true;
 #else
         public static bool IsDebug => false;
 #endif
 
-        public static string GenerateLogDump(AppSettings appSettings)
-        {
-            var result = new StringBuilder();
-            result.Append("DataVersion: ").AppendLine(DataVersion)
-                .Append("CurrentNation: ").AppendLine(CurrentLoadedNation?.ToString())
-                .Append("ServerType: ").AppendLine(appSettings.ToString());
-            return result.ToString();
-        }
+    public static string GenerateLogDump(AppSettings appSettings)
+    {
+        var result = new StringBuilder();
+        result.Append("DataVersion: ").AppendLine(DataVersion)
+            .Append("CurrentNation: ").AppendLine(CurrentLoadedNation?.ToString())
+            .Append("ServerType: ").AppendLine(appSettings.ToString());
+        return result.ToString();
+    }
 
-        public static void ResetCaches()
-        {
-            ShipSummaryList = null;
-            ConsumableList = null;
-            ProjectileCache.Clear();
-            AircraftCache.Clear();
-            ShipDictionary = null;
-            DataVersion = null;
-            Logging.Logger.Info("Cleared all appdata caches.");
-        }
+    public static void ResetCaches()
+    {
+        ShipSummaryList = null;
+        ConsumableList = null;
+        ProjectileCache.Clear();
+        AircraftCache.Clear();
+        ShipDictionary = null;
+        DataVersion = null;
+        Logging.Logger.Info("Cleared all appdata caches.");
     }
 }

--- a/WoWsShipBuilder.Core/Extensions/Extensions.cs
+++ b/WoWsShipBuilder.Core/Extensions/Extensions.cs
@@ -49,7 +49,7 @@ namespace WoWsShipBuilder.Core.Extensions
         /// <param name="content">The content dictionary for the key.</param>
         /// <typeparam name="T">The data type of the content dictionary.</typeparam>
         /// <returns><see langword="true"/> if the content was added, <see langword="false"/> otherwise.</returns>
-        public static bool SetIfNotNull<T>(this Dictionary<Nation, Dictionary<string, T>> thisDict, Nation nation, Dictionary<string, T>? content)
+        public static bool SetIfNotNull<T>(this IDictionary<Nation, Dictionary<string, T>> thisDict, Nation nation, Dictionary<string, T>? content)
         {
             if (content == null)
             {

--- a/WoWsShipBuilder.Core/Localization/Translation.Designer.cs
+++ b/WoWsShipBuilder.Core/Localization/Translation.Designer.cs
@@ -367,6 +367,15 @@ namespace WoWsShipBuilder.Core.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Right-click on a consumable to toggle its effects.
+        /// </summary>
+        public static string Consumable_RightClickToggle {
+            get {
+                return ResourceManager.GetString("Consumable_RightClickToggle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cruiser.
         /// </summary>
         public static string Cruiser {

--- a/WoWsShipBuilder.Core/Localization/Translation.Designer.cs
+++ b/WoWsShipBuilder.Core/Localization/Translation.Designer.cs
@@ -367,7 +367,7 @@ namespace WoWsShipBuilder.Core.Translations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Right-click on a consumable to toggle its effects.
+        ///   Looks up a localized string similar to Right-click an icon to toggle effects.
         /// </summary>
         public static string Consumable_RightClickToggle {
             get {

--- a/WoWsShipBuilder.Core/Localization/Translation.resx
+++ b/WoWsShipBuilder.Core/Localization/Translation.resx
@@ -1420,4 +1420,7 @@ They do not have any effect on surface ships.</value>
   <data name="ShipStats_ShipHp" xml:space="preserve">
       <value>Ship HP</value>
   </data>
+  <data name="Consumable_RightClickToggle" xml:space="preserve">
+      <value>Right-click on a consumable to toggle its effects</value>
+  </data>
 </root>

--- a/WoWsShipBuilder.Core/Localization/Translation.resx
+++ b/WoWsShipBuilder.Core/Localization/Translation.resx
@@ -1421,6 +1421,6 @@ They do not have any effect on surface ships.</value>
       <value>Ship HP</value>
   </data>
   <data name="Consumable_RightClickToggle" xml:space="preserve">
-      <value>Right-click on a consumable to toggle its effects</value>
+      <value>Right-click an icon to toggle effects</value>
   </data>
 </root>

--- a/WoWsShipBuilder.UI/App.axaml
+++ b/WoWsShipBuilder.UI/App.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:WoWsShipBuilder.UI"
              xmlns:translations="clr-namespace:WoWsShipBuilder.UI.Translations"
+             xmlns:converters="clr-namespace:WoWsShipBuilder.UI.Converters"
              x:Class="WoWsShipBuilder.UI.App">
     <Application.DataTemplates>
         <local:ViewLocator/>
@@ -19,5 +20,6 @@
     
     <Application.Resources>
         <translations:LocalizeConverter x:Key="Localizer" />
+        <converters:ImagePathConverter x:Key="ImageConverter" />
     </Application.Resources>
 </Application>

--- a/WoWsShipBuilder.UI/Converters/BooleanToBrushConverter.cs
+++ b/WoWsShipBuilder.UI/Converters/BooleanToBrushConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Globalization;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace WoWsShipBuilder.UI.Converters;
+
+public class BooleanToBrushConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool boolValue && targetType == typeof(IBrush))
+        {
+            return boolValue ? Brushes.Gold : Brushes.Transparent;
+        }
+
+        return new BindingNotification(new NotSupportedException());
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return new BindingNotification(new NotSupportedException());
+    }
+}

--- a/WoWsShipBuilder.UI/UserControls/ConsumablePanel.axaml
+++ b/WoWsShipBuilder.UI/UserControls/ConsumablePanel.axaml
@@ -4,23 +4,27 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:userControls="clr-namespace:WoWsShipBuilder.UI.UserControls"
              xmlns:shipVm="clr-namespace:WoWsShipBuilder.ViewModels.ShipVm;assembly=WoWsShipBuilder.ViewModels"
+             xmlns:translations="clr-namespace:WoWsShipBuilder.Core.Translations;assembly=WoWsShipBuilder.Core"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="WoWsShipBuilder.UI.UserControls.ConsumablePanel"
              Name="ConsumablePanel">
     <Design.DataContext>
         <shipVm:ConsumableViewModel />
     </Design.DataContext>
-
-    <ItemsControl Items="{Binding ConsumableSlots}">
-        <ItemsControl.ItemsPanel>
-            <ItemsPanelTemplate>
-                <StackPanel Orientation="Horizontal" Spacing="5"/>
-            </ItemsPanelTemplate>
-        </ItemsControl.ItemsPanel>
-        <ItemsControl.ItemTemplate>
-            <DataTemplate DataType="shipVm:ConsumableSlotViewModel">
-                <userControls:ConsumablePanelItem />
-            </DataTemplate>
-        </ItemsControl.ItemTemplate>
-    </ItemsControl>
+    
+    <StackPanel Orientation="Vertical" Spacing="2">
+        <ItemsControl HorizontalAlignment="Center" Items="{Binding ConsumableSlots}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" Spacing="5"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate DataType="shipVm:ConsumableSlotViewModel">
+                    <userControls:ConsumablePanelItem />
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Bottom" Text="{x:Static translations:Translation.Consumable_RightClickToggle}" />
+    </StackPanel>
 </UserControl>

--- a/WoWsShipBuilder.UI/UserControls/ConsumablePanel.axaml
+++ b/WoWsShipBuilder.UI/UserControls/ConsumablePanel.axaml
@@ -25,6 +25,6 @@
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
-        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Bottom" Text="{x:Static translations:Translation.Consumable_RightClickToggle}" />
+        <TextBlock HorizontalAlignment="Center" FontSize="12" Opacity="0.75" VerticalAlignment="Bottom" Text="{x:Static translations:Translation.Consumable_RightClickToggle}" />
     </StackPanel>
 </UserControl>

--- a/WoWsShipBuilder.UI/UserControls/ConsumablePanel.axaml
+++ b/WoWsShipBuilder.UI/UserControls/ConsumablePanel.axaml
@@ -2,9 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:converters="clr-namespace:WoWsShipBuilder.UI.Converters"
              xmlns:userControls="clr-namespace:WoWsShipBuilder.UI.UserControls"
-             xmlns:viewModels="clr-namespace:WoWsShipBuilder.UI.ViewModels;assembly=WoWsShipBuilder.ViewModels"
              xmlns:shipVm="clr-namespace:WoWsShipBuilder.ViewModels.ShipVm;assembly=WoWsShipBuilder.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="WoWsShipBuilder.UI.UserControls.ConsumablePanel"
@@ -12,101 +10,16 @@
     <Design.DataContext>
         <shipVm:ConsumableViewModel />
     </Design.DataContext>
-    <UserControl.Resources>
-        <converters:ConsumableUiConverter x:Key="ConsumableUiConverter" />
-        <converters:ImagePathConverter x:Key="ImageConverter" />
-        <converters:ConsumableListSizeConverter x:Key="ListSizeConverter" />
-    </UserControl.Resources>
 
-    <ItemsControl Items="{Binding ShipConsumables}">
+    <ItemsControl Items="{Binding ConsumableSlots}">
         <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
-                <StackPanel Orientation="Horizontal" Spacing="5" />
+                <StackPanel Orientation="Horizontal" Spacing="5"/>
             </ItemsPanelTemplate>
         </ItemsControl.ItemsPanel>
         <ItemsControl.ItemTemplate>
-            <DataTemplate>
-                <Panel>
-                    <Button Name="DropDownButton" Click="DropDownButton_OnClick" ToolTip.Placement="Right" ToolTip.HorizontalOffset="5"
-                            IsVisible="{Binding Converter={StaticResource ListSizeConverter}, ConverterParameter=2}">
-                        <Image MaxWidth="60">
-                            <Image.Styles>
-                                <Style Selector="Image">
-                                    <Setter Property="Source">
-                                        <MultiBinding Converter="{StaticResource ConsumableUiConverter}" ConverterParameter="image">
-                                            <Binding/>
-                                            <Binding Path="#ConsumablePanel.DataContext.SelectedConsumables" FallbackValue="null"/>
-                                        </MultiBinding>
-                                    </Setter>
-                                </Style>
-                            </Image.Styles>
-                        </Image>
-                        <ToolTip.Tip>
-                            <userControls:ModifierToolTip>
-                                <userControls:ModifierToolTip.Styles>
-                                    <Style Selector="userControls|ModifierToolTip">
-                                        <Setter Property="DataContext">
-                                            <MultiBinding Converter="{StaticResource ConsumableUiConverter}" ConverterParameter="data">
-                                                <Binding Path="$parent[Button].DataContext" FallbackValue="none" />
-                                                <Binding Path="$parent[UserControl].DataContext.SelectedConsumables" FallbackValue="null" />
-                                            </MultiBinding>
-                                        </Setter>
-                                    </Style>
-                                </userControls:ModifierToolTip.Styles>
-                            </userControls:ModifierToolTip>
-                        </ToolTip.Tip>
-                    </Button>
-                    <Image ToolTip.Placement="Right" ToolTip.HorizontalOffset="5" IsEnabled="{Binding $self.IsVisible}"
-                        IsVisible="{Binding Converter={StaticResource ListSizeConverter}, ConverterParameter=-2}" MaxWidth="60">
-                        <Image.Styles>
-                            <Style Selector="Image">
-                                <Setter Property="Source">
-                                    <MultiBinding Converter="{StaticResource ConsumableUiConverter}" ConverterParameter="image">
-                                        <Binding/>
-                                        <Binding Path="#ConsumablePanel.DataContext.SelectedConsumables" FallbackValue="null"/>
-                                    </MultiBinding>
-                                </Setter>
-                            </Style>
-                        </Image.Styles>
-                        <ToolTip.Tip>
-                            <userControls:ModifierToolTip>
-                                <userControls:ModifierToolTip.DataContext>
-                                    <MultiBinding Converter="{StaticResource ConsumableUiConverter}" ConverterParameter="data">
-                                        <Binding Path="$parent[Image].DataContext" />
-                                        <Binding Path="$parent[UserControl].DataContext.SelectedConsumables" FallbackValue="notSet" />
-                                    </MultiBinding>
-                                </userControls:ModifierToolTip.DataContext>
-                            </userControls:ModifierToolTip>
-                        </ToolTip.Tip>
-                    </Image>
-                    <Popup PlacementTarget="DropDownButton" PlacementAnchor="Bottom" Name="Popup" IsLightDismissEnabled="True">
-                        <ListBox Name="ListBox" Width="{Binding Path=#DropDownButton.Bounds.Width}" SelectionMode="Single" Items="{Binding}"
-                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                            <ListBox.Styles>
-                                <!-- Use style to avoid unset value error on property change. -->
-                                <Style Selector="ListBox">
-                                    <Setter Property="SelectedIndex">
-                                        <MultiBinding Converter="{StaticResource ConsumableUiConverter}" ConverterParameter="index" Mode="OneWay">
-                                            <Binding/>
-                                            <Binding Path="#ConsumablePanel.DataContext.SelectedConsumables" FallbackValue="null" />
-                                        </MultiBinding>
-                                    </Setter>
-                                </Style>
-                            </ListBox.Styles>
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <Image Source="{Binding Converter={StaticResource ImageConverter}}" 
-                                           PointerReleased="InputElement_OnPointerReleased" 
-                                           ToolTip.Placement="Right" ToolTip.HorizontalOffset="5">
-                                        <ToolTip.Tip>
-                                            <userControls:ModifierToolTip DataContext="{Binding}" />
-                                        </ToolTip.Tip>
-                                    </Image>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
-                    </Popup>
-                </Panel>
+            <DataTemplate DataType="shipVm:ConsumableSlotViewModel">
+                <userControls:ConsumablePanelItem />
             </DataTemplate>
         </ItemsControl.ItemTemplate>
     </ItemsControl>

--- a/WoWsShipBuilder.UI/UserControls/ConsumablePanel.axaml.cs
+++ b/WoWsShipBuilder.UI/UserControls/ConsumablePanel.axaml.cs
@@ -1,56 +1,17 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
-using Avalonia.Input;
-using Avalonia.Interactivity;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
-using WoWsShipBuilder.Core.DataContainers;
-using WoWsShipBuilder.ViewModels.ShipVm;
 
-namespace WoWsShipBuilder.UI.UserControls
+namespace WoWsShipBuilder.UI.UserControls;
+
+public class ConsumablePanel : UserControl
 {
-    public class ConsumablePanel : UserControl
+    public ConsumablePanel()
     {
-        public ConsumablePanel()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
+    }
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-
-        private void DropDownButton_OnClick(object? sender, RoutedEventArgs e)
-        {
-            if (sender is Button button)
-            {
-                var parent = button.Parent;
-                var optionsPopup = parent?.LogicalChildren.FirstOrDefault(child => child is Popup) as Popup;
-                if (optionsPopup?.DataContext is List<ConsumableDataContainer> { Count: > 1 })
-                {
-                    optionsPopup.IsOpen = true;
-                }
-            }
-        }
-
-        private void InputElement_OnPointerReleased(object? sender, PointerReleasedEventArgs e)
-        {
-            if (sender is Image image)
-            {
-                if (DataContext is ConsumableViewModel viewModel && image.DataContext is ConsumableDataContainer consumableUi)
-                {
-                    var parent = image.Parent;
-                    while (parent is not Popup && parent != null)
-                    {
-                        parent = parent.Parent;
-                    }
-
-                    ((Popup)parent!).IsOpen = false;
-                    viewModel.OnConsumableSelected.Invoke(consumableUi);
-                }
-            }
-        }
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
     }
 }

--- a/WoWsShipBuilder.UI/UserControls/ConsumablePanelItem.axaml
+++ b/WoWsShipBuilder.UI/UserControls/ConsumablePanelItem.axaml
@@ -1,0 +1,53 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:shipVm="clr-namespace:WoWsShipBuilder.ViewModels.ShipVm;assembly=WoWsShipBuilder.ViewModels"
+             xmlns:userControls="clr-namespace:WoWsShipBuilder.UI.UserControls"
+             xmlns:converters="clr-namespace:WoWsShipBuilder.UI.Converters"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="WoWsShipBuilder.UI.UserControls.ConsumablePanelItem">
+    <UserControl.Resources>
+        <converters:ConsumableListSizeConverter x:Key="ListSizeConverter" />
+        <converters:BooleanToBrushConverter x:Key="BrushConverter" /> 
+    </UserControl.Resources>
+
+    <Design.DataContext>
+        <shipVm:ConsumableSlotViewModel />
+    </Design.DataContext>
+
+    <Border BorderBrush="{Binding ConsumableActivated, Converter={StaticResource BrushConverter}, FallbackValue=Transparent}" BorderThickness="1">
+        <Panel Width="70" Height="70" PointerReleased="ContentPanel_OnPointerReleased">
+            <Button Name="DropDownButton" Click="DropDownButton_OnClick" ToolTip.Placement="Right" ToolTip.HorizontalOffset="5"
+                    IsVisible="{Binding ConsumableData, Converter={StaticResource ListSizeConverter}, ConverterParameter=2}">
+                <Image MaxWidth="60" Source="{Binding SelectedConsumable, Converter={StaticResource ImageConverter}}" />
+                <ToolTip.Tip>
+                    <userControls:ModifierToolTip DataContext="{Binding SelectedConsumable}" />
+                </ToolTip.Tip>
+            </Button>
+            <Image ToolTip.Placement="Right" ToolTip.HorizontalOffset="5" IsEnabled="{Binding $self.IsVisible}"
+                   IsVisible="{Binding ConsumableData, Converter={StaticResource ListSizeConverter}, ConverterParameter=-2}"
+                   MaxWidth="60" Source="{Binding SelectedConsumable, Converter={StaticResource ImageConverter}}">
+                <ToolTip.Tip>
+                    <userControls:ModifierToolTip DataContext="{Binding SelectedConsumable}" />
+                </ToolTip.Tip>
+            </Image>
+            <Popup PlacementTarget="DropDownButton" PlacementAnchor="Bottom" Name="Popup" IsLightDismissEnabled="True">
+                <ListBox Name="ListBox" Width="{Binding Path=#DropDownButton.Bounds.Width}" SelectionMode="Single" Items="{Binding ConsumableData}"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled" SelectedIndex="{Binding SelectedIndex, Mode=OneWay}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <Image Source="{Binding Converter={StaticResource ImageConverter}}"
+                                   PointerReleased="InputElement_OnPointerReleased"
+                                   ToolTip.Placement="Right" ToolTip.HorizontalOffset="5">
+                                <ToolTip.Tip>
+                                    <userControls:ModifierToolTip DataContext="{Binding}" />
+                                </ToolTip.Tip>
+                            </Image>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Popup>
+        </Panel>
+    </Border>
+</UserControl>

--- a/WoWsShipBuilder.UI/UserControls/ConsumablePanelItem.axaml.cs
+++ b/WoWsShipBuilder.UI/UserControls/ConsumablePanelItem.axaml.cs
@@ -1,0 +1,62 @@
+﻿using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using WoWsShipBuilder.Core.DataContainers;
+using WoWsShipBuilder.ViewModels.ShipVm;
+
+namespace WoWsShipBuilder.UI.UserControls;
+
+public partial class ConsumablePanelItem : UserControl
+{
+    public ConsumablePanelItem()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void DropDownButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Button button)
+        {
+            var parent = button.Parent;
+            var optionsPopup = parent?.LogicalChildren.FirstOrDefault(child => child is Popup) as Popup;
+            if (optionsPopup?.DataContext is ConsumableSlotViewModel { ConsumableData.Count: > 1 })
+            {
+                optionsPopup.IsOpen = true;
+            }
+        }
+    }
+
+    private void InputElement_OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (sender is Image image)
+        {
+            if (DataContext is ConsumableSlotViewModel viewModel && image.DataContext is ConsumableDataContainer consumableData)
+            {
+                var parent = image.Parent;
+                while (parent is not Popup && parent != null)
+                {
+                    parent = parent.Parent;
+                }
+
+                ((Popup)parent!).IsOpen = false;
+                viewModel.SelectedIndex = viewModel.ConsumableData.IndexOf(consumableData);
+            }
+        }
+    }
+
+    private void ContentPanel_OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (e.InitialPressMouseButton == MouseButton.Right && DataContext is ConsumableSlotViewModel viewModel)
+        {
+            viewModel.ConsumableActivated = !viewModel.ConsumableActivated;
+        }
+    }
+}

--- a/WoWsShipBuilder.UI/UserControls/ConsumableSelector.axaml.cs
+++ b/WoWsShipBuilder.UI/UserControls/ConsumableSelector.axaml.cs
@@ -12,6 +12,7 @@ using WoWsShipBuilder.UI.Converters;
 
 namespace WoWsShipBuilder.UI.UserControls
 {
+    [Obsolete("Use ConsumablePanel instead")]
     public class ConsumableSelector : UserControl
     {
         #region Static Fields and Constants

--- a/WoWsShipBuilder.UI/ViewModels/ScreenshotContainerViewModel.cs
+++ b/WoWsShipBuilder.UI/ViewModels/ScreenshotContainerViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -77,7 +78,7 @@ namespace WoWsShipBuilder.UI.ViewModels
                 CaptainSkillSelectorViewModel = new(ship.ShipClass, await CaptainSkillSelectorViewModel.LoadParamsAsync(appDataService, AppSettingsHelper.Settings, ship.ShipNation), true),
                 SignalSelectorViewModel = new(await SignalSelectorViewModel.LoadSignalList(appDataService, AppSettingsHelper.Settings)),
                 UpgradePanelViewModel = new UpgradePanelViewModel(ship, await UpgradePanelViewModelBase.LoadParamsAsync(appDataService, AppSettingsHelper.Settings)),
-                ConsumableViewModel = await ConsumableViewModel.CreateAsync(ship, 0),
+                ConsumableViewModel = await ConsumableViewModel.CreateAsync(appDataService, ship, new List<string>()),
             };
             vm.LoadBuilds(build);
             return vm;

--- a/WoWsShipBuilder.ViewModels/ShipVm/ConsumableSlotViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/ConsumableSlotViewModel.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ReactiveUI;
+using WoWsShipBuilder.Core.DataContainers;
+using WoWsShipBuilder.Core.DataProvider;
+using WoWsShipBuilder.Core.Services;
+using WoWsShipBuilder.DataStructures;
+using WoWsShipBuilder.ViewModels.Base;
+
+namespace WoWsShipBuilder.ViewModels.ShipVm;
+
+public class ConsumableSlotViewModel : ViewModelBase
+{
+    private readonly Action<int, bool>? activationChangeHandler;
+    private readonly IAppDataService appDataService;
+    private readonly List<ShipConsumable> shipConsumables;
+
+    private bool consumableActivated;
+
+    private List<ConsumableDataContainer> consumableData = new();
+
+    private int selectedIndex;
+
+    public ConsumableSlotViewModel()
+        : this(DesktopAppDataService.PreviewInstance, new List<ShipConsumable>(), null)
+    {
+    }
+
+    private ConsumableSlotViewModel(IAppDataService appDataService, IEnumerable<ShipConsumable> shipConsumables, Action<int, bool>? activationChangeHandler)
+    {
+        this.appDataService = appDataService;
+        this.activationChangeHandler = activationChangeHandler;
+        this.shipConsumables = new(shipConsumables);
+        Slot = this.shipConsumables.First().Slot;
+    }
+
+    public int Slot { get; }
+
+    public List<ConsumableDataContainer> ConsumableData
+    {
+        get => consumableData;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref consumableData, value);
+            this.RaisePropertyChanged(nameof(SelectedIndex)); // Necessary to update index for selection popup
+        }
+    }
+
+    public int SelectedIndex
+    {
+        get => selectedIndex;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref selectedIndex, value);
+            this.RaisePropertyChanged(nameof(SelectedConsumable));
+            ConsumableActivated = false;
+        }
+    }
+
+    public bool ConsumableActivated
+    {
+        get => consumableActivated;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref consumableActivated, value);
+            activationChangeHandler?.Invoke(Slot, value);
+        }
+    }
+
+    public ConsumableDataContainer SelectedConsumable => ConsumableData[SelectedIndex];
+
+    public static async Task<ConsumableSlotViewModel> CreateAsync(IAppDataService appDataService, IEnumerable<ShipConsumable> shipConsumables, Action<int, bool>? activationChangeHandler = null)
+    {
+        var vm = new ConsumableSlotViewModel(appDataService, shipConsumables, activationChangeHandler);
+        await vm.UpdateDataContainers(new(), 0);
+        return vm;
+    }
+
+    public async Task UpdateDataContainers(List<(string, float)> modifiers, int shipHp)
+    {
+        var dataContainers = await Task.WhenAll(shipConsumables
+            .Select(async c => await ConsumableDataContainer.FromTypeAndVariant(c, modifiers, false, 0, shipHp, appDataService)));
+        ConsumableData = dataContainers.ToList();
+    }
+}

--- a/WoWsShipBuilder.ViewModels/ShipVm/MainWindowViewModelBase.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/MainWindowViewModelBase.cs
@@ -22,315 +22,315 @@ using WoWsShipBuilder.ViewModels.Base;
 using WoWsShipBuilder.ViewModels.Helper;
 using WoWsShipBuilder.ViewModels.Other;
 
-namespace WoWsShipBuilder.ViewModels.ShipVm
+namespace WoWsShipBuilder.ViewModels.ShipVm;
+
+public abstract class MainWindowViewModelBase : ViewModelBase
 {
-    public abstract class MainWindowViewModelBase : ViewModelBase
+    private readonly SemaphoreSlim semaphore = new(1, 1);
+
+    private readonly CompositeDisposable disposables = new();
+
+    private readonly INavigationService navigationService;
+
+    private readonly IAppDataService appDataService;
+
+    private readonly ILocalizer localizer;
+
+    private readonly AppSettings appSettings;
+
+    private CaptainSkillSelectorViewModel? captainSkillSelectorViewModel;
+
+    private ConsumableViewModel consumableViewModel = null!;
+
+    private string? currentShipIndex = "_default";
+
+    private int? currentShipTier;
+
+    private Ship effectiveShipData = null!;
+
+    private List<ShipSummary>? nextShips = new();
+
+    private ShipSummary? currentShip;
+
+    private ShipSummary? previousShip;
+
+    private Ship rawShipData = null!;
+
+    private ShipModuleViewModel shipModuleViewModel = null!;
+
+    private ShipStatsControlViewModelBase? shipStatsControlViewModel;
+
+    private SignalSelectorViewModel? signalSelectorViewModel;
+
+    private CancellationTokenSource tokenSource;
+
+    private UpgradePanelViewModelBase upgradePanelViewModel = null!;
+
+    protected string? CurrentBuildName;
+
+    protected MainWindowViewModelBase(INavigationService navigationService, IAppDataService appDataService, ILocalizer localizer, AppSettings appSettings, MainViewModelParams viewModelParams)
     {
-        private readonly SemaphoreSlim semaphore = new(1, 1);
+        this.navigationService = navigationService;
+        this.appDataService = appDataService;
+        this.localizer = localizer;
+        this.appSettings = appSettings;
+        tokenSource = new();
+        PreviousShip = viewModelParams.ShipSummary.PrevShipIndex is null ? null : AppData.ShipSummaryList!.First(sum => sum.Index == viewModelParams.ShipSummary.PrevShipIndex);
+        CurrentShip = viewModelParams.ShipSummary;
 
-        private readonly CompositeDisposable disposables = new();
+        LoadShipFromIndexCommand = ReactiveCommand.CreateFromTask<string>(LoadShipFromIndexExecute);
+    }
 
-        private readonly INavigationService navigationService;
+    public string? CurrentShipIndex
+    {
+        get => currentShipIndex;
+        set => this.RaiseAndSetIfChanged(ref currentShipIndex, value);
+    }
 
-        private readonly IAppDataService appDataService;
+    public int? CurrentShipTier
+    {
+        get => currentShipTier;
+        set => this.RaiseAndSetIfChanged(ref currentShipTier, value);
+    }
 
-        private readonly ILocalizer localizer;
+    public ShipSummary? CurrentShip
+    {
+        get => currentShip;
+        set => this.RaiseAndSetIfChanged(ref currentShip, value);
+    }
 
-        private readonly AppSettings appSettings;
+    public ShipSummary? PreviousShip
+    {
+        get => previousShip;
+        set => this.RaiseAndSetIfChanged(ref previousShip, value);
+    }
 
-        private CaptainSkillSelectorViewModel? captainSkillSelectorViewModel;
+    public List<ShipSummary>? NextShips
+    {
+        get => nextShips;
+        set => this.RaiseAndSetIfChanged(ref nextShips, value);
+    }
 
-        private ConsumableViewModel consumableViewModel = null!;
+    public ShipModuleViewModel ShipModuleViewModel
+    {
+        get => shipModuleViewModel;
+        set => this.RaiseAndSetIfChanged(ref shipModuleViewModel, value);
+    }
 
-        private string? currentShipIndex = "_default";
+    public SignalSelectorViewModel? SignalSelectorViewModel
+    {
+        get => signalSelectorViewModel;
+        set => this.RaiseAndSetIfChanged(ref signalSelectorViewModel, value);
+    }
 
-        private int? currentShipTier;
+    public ShipStatsControlViewModelBase? ShipStatsControlViewModel
+    {
+        get => shipStatsControlViewModel;
+        set => this.RaiseAndSetIfChanged(ref shipStatsControlViewModel, value);
+    }
 
-        private Ship effectiveShipData = null!;
+    public CaptainSkillSelectorViewModel? CaptainSkillSelectorViewModel
+    {
+        get => captainSkillSelectorViewModel;
+        set => this.RaiseAndSetIfChanged(ref captainSkillSelectorViewModel, value);
+    }
 
-        private List<ShipSummary>? nextShips = new();
+    public ConsumableViewModel ConsumableViewModel
+    {
+        get => consumableViewModel;
+        set => this.RaiseAndSetIfChanged(ref consumableViewModel, value);
+    }
 
-        private ShipSummary? currentShip;
+    public UpgradePanelViewModelBase UpgradePanelViewModel
+    {
+        get => upgradePanelViewModel;
+        set => this.RaiseAndSetIfChanged(ref upgradePanelViewModel, value);
+    }
 
-        private ShipSummary? previousShip;
+    public Ship EffectiveShipData
+    {
+        get => effectiveShipData;
+        set => this.RaiseAndSetIfChanged(ref effectiveShipData, value);
+    }
 
-        private Ship rawShipData = null!;
+    protected Ship RawShipData
+    {
+        get => rawShipData;
+        set => this.RaiseAndSetIfChanged(ref rawShipData, value);
+    }
 
-        private ShipModuleViewModel shipModuleViewModel = null!;
+    public async void ResetBuild()
+    {
+        Logging.Logger.Info("Resetting build");
+        await LoadNewShip(AppData.ShipSummaryList!.First(summary => summary.Index.Equals(CurrentShipIndex)));
+    }
 
-        private ShipStatsControlViewModelBase? shipStatsControlViewModel;
+    public Interaction<BuildCreationWindowViewModel, BuildCreationResult?> BuildCreationInteraction { get; } = new();
 
-        private SignalSelectorViewModel? signalSelectorViewModel;
+    public Interaction<string, Unit> BuildCreatedInteraction { get; } = new();
 
-        private CancellationTokenSource tokenSource;
+    public abstract void OpenSaveBuild();
 
-        private UpgradePanelViewModelBase upgradePanelViewModel = null!;
+    // Handle(true) closes this window too
+    public Interaction<Unit, Unit> CloseChildrenInteraction { get; } = new();
 
-        protected string? CurrentBuildName;
+    public Interaction<StartMenuViewModelBase, Unit> OpenStartMenuInteraction { get; } = new();
 
-        protected MainWindowViewModelBase(INavigationService navigationService, IAppDataService appDataService, ILocalizer localizer, AppSettings appSettings, MainViewModelParams viewModelParams)
+    public ICommand LoadShipFromIndexCommand { get; }
+
+    public void BackToMenu()
+    {
+        navigationService.OpenStartMenu(true);
+    }
+
+    public Interaction<ShipSelectionWindowViewModel, List<ShipSummary>?> SelectNewShipInteraction { get; } = new();
+
+    public async void NewShipSelection()
+    {
+        Logging.Logger.Info("Selecting new ship");
+
+        var result = (await SelectNewShipInteraction.Handle(new(false, await ShipSelectionWindowViewModel.LoadParamsAsync(appDataService, appSettings, localizer))))?.FirstOrDefault();
+        if (result != null)
         {
-            this.navigationService = navigationService;
-            this.appDataService = appDataService;
-            this.localizer = localizer;
-            this.appSettings = appSettings;
-            tokenSource = new();
-            PreviousShip = viewModelParams.ShipSummary.PrevShipIndex is null ? null : AppData.ShipSummaryList!.First(sum => sum.Index == viewModelParams.ShipSummary.PrevShipIndex);
-            CurrentShip = viewModelParams.ShipSummary;
+            Logging.Logger.Info("New ship selected: {0}", result.Index);
+            await LoadNewShip(result);
+        }
+    }
 
-            LoadShipFromIndexCommand = ReactiveCommand.CreateFromTask<string>(LoadShipFromIndexExecute);
+    private async Task LoadShipFromIndexExecute(string shipIndex)
+    {
+        var shipSummary = AppData.ShipSummaryList!.First(summary => summary.Index == shipIndex);
+        await LoadNewShip(shipSummary);
+    }
+
+    private async Task LoadNewShip(ShipSummary summary)
+    {
+        // only close child windows
+        await CloseChildrenInteraction.Handle(Unit.Default);
+
+        disposables.Clear();
+        var ship = await appDataService.GetShipFromSummary(summary);
+        await appDataService.LoadNationFiles(summary.Nation);
+
+        await InitializeData(ship!, summary.PrevShipIndex, summary.NextShipsIndex);
+    }
+
+    public async Task InitializeData(MainViewModelParams viewModelParams)
+    {
+        await InitializeData(viewModelParams.Ship, viewModelParams.ShipSummary.PrevShipIndex, viewModelParams.ShipSummary.NextShipsIndex, viewModelParams.Build);
+    }
+
+    private async Task InitializeData(Ship ship, string? previousIndex, List<string>? nextShipsIndexes, Build? build = null)
+    {
+        Logging.Logger.Info("Loading data for ship {0}", ship.Index);
+        Logging.Logger.Info("Build is null: {0}", build is null);
+
+        ShipDataContainer.ExpanderStateMapper.Clear();
+
+        // Ship stats model
+        RawShipData = ship;
+        EffectiveShipData = RawShipData;
+
+        Logging.Logger.Info("Initializing view models");
+
+        // Viewmodel inits
+        SignalSelectorViewModel = new(await SignalSelectorViewModel.LoadSignalList(appDataService, appSettings));
+        CaptainSkillSelectorViewModel = new(RawShipData.ShipClass, await CaptainSkillSelectorViewModel.LoadParamsAsync(appDataService, appSettings, ship.ShipNation));
+        ShipModuleViewModel = new(RawShipData.ShipUpgradeInfo);
+        UpgradePanelViewModel = new(RawShipData, await UpgradePanelViewModelBase.LoadParamsAsync(appDataService, appSettings));
+        ConsumableViewModel = await ConsumableViewModel.CreateAsync(appDataService, RawShipData, new List<string>());
+
+        ShipStatsControlViewModel = new(EffectiveShipData, ShipModuleViewModel.SelectedModules.ToList(), GenerateModifierList(), appDataService, localizer);
+
+        if (build != null)
+        {
+            Logging.Logger.Info("Loading build");
+            SignalSelectorViewModel.LoadBuild(build.Signals);
+            CaptainSkillSelectorViewModel.LoadBuild(build.Skills, build.Captain);
+            ShipModuleViewModel.LoadBuild(build.Modules);
+            UpgradePanelViewModel.LoadBuild(build.Upgrades);
+            ConsumableViewModel.LoadBuild(build.Consumables);
         }
 
-        public string? CurrentShipIndex
+
+        CurrentShipIndex = ship.Index;
+        CurrentShipTier = ship.Tier;
+        CurrentShip = AppData.ShipSummaryList!.First(sum => sum.Index == ship.Index);
+        PreviousShip = previousIndex is null ? null : AppData.ShipSummaryList!.First(sum => sum.Index == previousIndex);
+        NextShips = nextShipsIndexes?.Select(index => AppData.ShipSummaryList!.First(sum => sum.Index == index)).ToList();
+
+        AddChangeListeners();
+        UpdateStatsViewModel();
+        if (build != null)
         {
-            get => currentShipIndex;
-            set => this.RaiseAndSetIfChanged(ref currentShipIndex, value);
+            CurrentBuildName = build.BuildName;
         }
+    }
 
-        public int? CurrentShipTier
+    private void AddChangeListeners()
+    {
+        ShipModuleViewModel.SelectedModules.ToObservableChangeSet().Do(_ => UpdateStatsViewModel()).Subscribe().DisposeWith(disposables);
+        UpgradePanelViewModel.SelectedModernizationList.ToObservableChangeSet().Do(_ => UpdateStatsViewModel()).Subscribe().DisposeWith(disposables);
+        SignalSelectorViewModel?.SelectedSignals.ToObservableChangeSet().Do(_ => UpdateStatsViewModel()).Subscribe().DisposeWith(disposables);
+        CaptainSkillSelectorViewModel?.SkillOrderList.ToObservableChangeSet().Do(_ => UpdateStatsViewModel()).Subscribe().DisposeWith(disposables);
+        ConsumableViewModel.ActivatedSlots.ToObservableChangeSet().Do(_ => UpdateStatsViewModel()).Subscribe().DisposeWith(disposables);
+
+        CaptainSkillSelectorViewModel.WhenAnyValue(x => x.SkillActivationPopupOpen).Subscribe(HandleCaptainParamsChange).DisposeWith(disposables);
+        CaptainSkillSelectorViewModel.WhenAnyValue(x => x.CaptainWithTalents).Subscribe(HandleCaptainParamsChange).DisposeWith(disposables);
+        CaptainSkillSelectorViewModel.WhenAnyValue(x => x.CamoEnabled).Subscribe(_ => UpdateStatsViewModel()).DisposeWith(disposables);
+    }
+
+    private void HandleCaptainParamsChange(bool newValue)
+    {
+        if (!newValue)
         {
-            get => currentShipTier;
-            set => this.RaiseAndSetIfChanged(ref currentShipTier, value);
-        }
-
-        public ShipSummary? CurrentShip
-        {
-            get => currentShip;
-            set => this.RaiseAndSetIfChanged(ref currentShip, value);
-        }
-
-        public ShipSummary? PreviousShip
-        {
-            get => previousShip;
-            set => this.RaiseAndSetIfChanged(ref previousShip, value);
-        }
-
-        public List<ShipSummary>? NextShips
-        {
-            get => nextShips;
-            set => this.RaiseAndSetIfChanged(ref nextShips, value);
-        }
-
-        public ShipModuleViewModel ShipModuleViewModel
-        {
-            get => shipModuleViewModel;
-            set => this.RaiseAndSetIfChanged(ref shipModuleViewModel, value);
-        }
-
-        public SignalSelectorViewModel? SignalSelectorViewModel
-        {
-            get => signalSelectorViewModel;
-            set => this.RaiseAndSetIfChanged(ref signalSelectorViewModel, value);
-        }
-
-        public ShipStatsControlViewModelBase? ShipStatsControlViewModel
-        {
-            get => shipStatsControlViewModel;
-            set => this.RaiseAndSetIfChanged(ref shipStatsControlViewModel, value);
-        }
-
-        public CaptainSkillSelectorViewModel? CaptainSkillSelectorViewModel
-        {
-            get => captainSkillSelectorViewModel;
-            set => this.RaiseAndSetIfChanged(ref captainSkillSelectorViewModel, value);
-        }
-
-        public ConsumableViewModel ConsumableViewModel
-        {
-            get => consumableViewModel;
-            set => this.RaiseAndSetIfChanged(ref consumableViewModel, value);
-        }
-
-        public UpgradePanelViewModelBase UpgradePanelViewModel
-        {
-            get => upgradePanelViewModel;
-            set => this.RaiseAndSetIfChanged(ref upgradePanelViewModel, value);
-        }
-
-        public Ship EffectiveShipData
-        {
-            get => effectiveShipData;
-            set => this.RaiseAndSetIfChanged(ref effectiveShipData, value);
-        }
-
-        protected Ship RawShipData
-        {
-            get => rawShipData;
-            set => this.RaiseAndSetIfChanged(ref rawShipData, value);
-        }
-
-        public async void ResetBuild()
-        {
-            Logging.Logger.Info("Resetting build");
-            await LoadNewShip(AppData.ShipSummaryList!.First(summary => summary.Index.Equals(CurrentShipIndex)));
-        }
-
-        public Interaction<BuildCreationWindowViewModel, BuildCreationResult?> BuildCreationInteraction { get; } = new();
-
-        public Interaction<string, Unit> BuildCreatedInteraction { get; } = new();
-
-        public abstract void OpenSaveBuild();
-
-        // Handle(true) closes this window too
-        public Interaction<Unit, Unit> CloseChildrenInteraction { get; } = new();
-
-        public Interaction<StartMenuViewModelBase, Unit> OpenStartMenuInteraction { get; } = new();
-
-        public ICommand LoadShipFromIndexCommand { get; }
-
-        public void BackToMenu()
-        {
-            navigationService.OpenStartMenu(true);
-        }
-
-        public Interaction<ShipSelectionWindowViewModel, List<ShipSummary>?> SelectNewShipInteraction { get; } = new();
-
-        public async void NewShipSelection()
-        {
-            Logging.Logger.Info("Selecting new ship");
-
-            var result = (await SelectNewShipInteraction.Handle(new(false, await ShipSelectionWindowViewModel.LoadParamsAsync(appDataService, appSettings, localizer))))?.FirstOrDefault();
-            if (result != null)
-            {
-                Logging.Logger.Info("New ship selected: {0}", result.Index);
-                await LoadNewShip(result);
-            }
-        }
-
-        private async Task LoadShipFromIndexExecute(string shipIndex)
-        {
-            var shipSummary = AppData.ShipSummaryList!.First(summary => summary.Index == shipIndex);
-            await LoadNewShip(shipSummary);
-        }
-
-        private async Task LoadNewShip(ShipSummary summary)
-        {
-            // only close child windows
-            await CloseChildrenInteraction.Handle(Unit.Default);
-
-            disposables.Clear();
-            var ship = await appDataService.GetShipFromSummary(summary);
-            await appDataService.LoadNationFiles(summary.Nation);
-
-            await InitializeData(ship!, summary.PrevShipIndex, summary.NextShipsIndex);
-        }
-
-        public async Task InitializeData(MainViewModelParams viewModelParams)
-        {
-            await InitializeData(viewModelParams.Ship, viewModelParams.ShipSummary.PrevShipIndex, viewModelParams.ShipSummary.NextShipsIndex, viewModelParams.Build);
-        }
-
-        private async Task InitializeData(Ship ship, string? previousIndex, List<string>? nextShipsIndexes, Build? build = null)
-        {
-            Logging.Logger.Info("Loading data for ship {0}", ship.Index);
-            Logging.Logger.Info("Build is null: {0}", build is null);
-
-            ShipDataContainer.ExpanderStateMapper.Clear();
-
-            // Ship stats model
-            RawShipData = ship;
-            EffectiveShipData = RawShipData;
-
-            Logging.Logger.Info("Initializing view models");
-
-            // Viewmodel inits
-            SignalSelectorViewModel = new(await SignalSelectorViewModel.LoadSignalList(appDataService, appSettings));
-            CaptainSkillSelectorViewModel = new(RawShipData.ShipClass, await CaptainSkillSelectorViewModel.LoadParamsAsync(appDataService, appSettings, ship.ShipNation));
-            ShipModuleViewModel = new(RawShipData.ShipUpgradeInfo);
-            UpgradePanelViewModel = new(RawShipData, await UpgradePanelViewModelBase.LoadParamsAsync(appDataService, appSettings));
-
-            ShipStatsControlViewModel = new(EffectiveShipData, ShipModuleViewModel.SelectedModules.ToList(), GenerateModifierList(), appDataService, localizer);
-
-            ConsumableViewModel = await ConsumableViewModel.CreateAsync(RawShipData, 0);
-
-            if (build != null)
-            {
-                Logging.Logger.Info("Loading build");
-                SignalSelectorViewModel.LoadBuild(build.Signals);
-                CaptainSkillSelectorViewModel.LoadBuild(build.Skills, build.Captain);
-                ShipModuleViewModel.LoadBuild(build.Modules);
-                UpgradePanelViewModel.LoadBuild(build.Upgrades);
-                ConsumableViewModel.LoadBuild(build.Consumables);
-            }
-
-
-            CurrentShipIndex = ship.Index;
-            CurrentShipTier = ship.Tier;
-            CurrentShip = AppData.ShipSummaryList!.First(sum => sum.Index == ship.Index);
-            PreviousShip = previousIndex is null ? null : AppData.ShipSummaryList!.First(sum => sum.Index == previousIndex);
-            NextShips = nextShipsIndexes?.Select(index => AppData.ShipSummaryList!.First(sum => sum.Index == index)).ToList();
-
-            AddChangeListeners();
             UpdateStatsViewModel();
-            if (build != null)
+        }
+    }
+
+    private void UpdateStatsViewModel()
+    {
+        tokenSource.Cancel();
+        tokenSource.Dispose();
+        tokenSource = new();
+        CancellationToken token = tokenSource.Token;
+        CurrentBuildName = null;
+        Task.Run(
+            async () =>
             {
-                CurrentBuildName = build.BuildName;
-            }
-        }
-
-        private void AddChangeListeners()
-        {
-            ShipModuleViewModel.SelectedModules.ToObservableChangeSet().Do(_ => UpdateStatsViewModel()).Subscribe().DisposeWith(disposables);
-            UpgradePanelViewModel.SelectedModernizationList.ToObservableChangeSet().Do(_ => UpdateStatsViewModel()).Subscribe().DisposeWith(disposables);
-            SignalSelectorViewModel?.SelectedSignals.ToObservableChangeSet().Do(_ => UpdateStatsViewModel()).Subscribe().DisposeWith(disposables);
-            CaptainSkillSelectorViewModel?.SkillOrderList.ToObservableChangeSet().Do(_ => UpdateStatsViewModel()).Subscribe().DisposeWith(disposables);
-
-            CaptainSkillSelectorViewModel.WhenAnyValue(x => x.SkillActivationPopupOpen).Subscribe(HandleCaptainParamsChange).DisposeWith(disposables);
-            CaptainSkillSelectorViewModel.WhenAnyValue(x => x.CaptainWithTalents).Subscribe(HandleCaptainParamsChange).DisposeWith(disposables);
-            CaptainSkillSelectorViewModel.WhenAnyValue(x => x.CamoEnabled).Subscribe(_ => UpdateStatsViewModel()).DisposeWith(disposables);
-        }
-
-        private void HandleCaptainParamsChange(bool newValue)
-        {
-            if (!newValue)
-            {
-                UpdateStatsViewModel();
-            }
-        }
-
-        private void UpdateStatsViewModel()
-        {
-            tokenSource.Cancel();
-            tokenSource.Dispose();
-            tokenSource = new();
-            CancellationToken token = tokenSource.Token;
-            CurrentBuildName = null;
-            Task.Run(
-                async () =>
+                try
                 {
-                    try
+                    await Task.Delay(250, token);
+                    if (!token.IsCancellationRequested)
                     {
-                        await Task.Delay(250, token);
-                        if (!token.IsCancellationRequested)
+                        await semaphore.WaitAsync(token);
+                        var modifiers = GenerateModifierList();
+                        if (ShipStatsControlViewModel != null)
                         {
-                            await semaphore.WaitAsync(token);
-                            var modifiers = GenerateModifierList();
-                            if (ShipStatsControlViewModel != null)
-                            {
-                                Logging.Logger.Info("Updating ship stats");
-                                await ShipStatsControlViewModel.UpdateShipStats(ShipModuleViewModel.SelectedModules.ToList(), modifiers);
-                            }
-                            var hp = ShipStatsControlViewModel!.CurrentShipStats!.SurvivabilityDataContainer.HitPoints;
-                            await ConsumableViewModel.UpdateShipConsumables(modifiers, hp);
-                            semaphore.Release();
+                            Logging.Logger.Info("Updating ship stats");
+                            await ShipStatsControlViewModel.UpdateShipStats(ShipModuleViewModel.SelectedModules.ToList(), modifiers);
                         }
+                        var hp = ShipStatsControlViewModel!.CurrentShipStats!.SurvivabilityDataContainer.HitPoints;
+                        await ConsumableViewModel.UpdateConsumableData(modifiers, hp);
+                        semaphore.Release();
                     }
-                    catch (OperationCanceledException)
-                    {
-                        // ignored
-                    }
-                },
-                token);
-        }
+                }
+                catch (OperationCanceledException)
+                {
+                    // ignored
+                }
+            },
+            token);
+    }
 
-        private List<(string, float)> GenerateModifierList()
-        {
-            var modifiers = new List<(string, float)>();
+    private List<(string, float)> GenerateModifierList()
+    {
+        var modifiers = new List<(string, float)>();
 
-            modifiers.AddRange(UpgradePanelViewModel.GetModifierList());
-            modifiers.AddRange(SignalSelectorViewModel!.GetModifierList());
-            modifiers.AddRange(CaptainSkillSelectorViewModel!.GetModifiersList());
-            return modifiers;
-        }
+        modifiers.AddRange(UpgradePanelViewModel.GetModifierList());
+        modifiers.AddRange(SignalSelectorViewModel!.GetModifierList());
+        modifiers.AddRange(CaptainSkillSelectorViewModel!.GetModifiersList());
+        modifiers.AddRange(ConsumableViewModel.GetModifiersList());
+        return modifiers;
     }
 }


### PR DESCRIPTION
# Goal

It should be possible to include consumables that affect the statistics of a ship, even if only temporary, in the displayed ship stats.

# Tasks

- [x] Refactor ConsumableViewModel. The current viewmodel is very old, badly structured and hard to update.
- [x] Add right-click listener and visual indication for activated consumables
- [x] Include consumable modifiers in effective ship statistics
- [x] Ensure all consumable modifiers are handled correctly
- [ ] (Optional) Allow activation only for consumables that actually affect ship stats
