### PR TITLE
Source generation for observable properties

### DIFF
--- a/WoWsShipBuilder.Data.Generator/Internals/Visibility.cs
+++ b/WoWsShipBuilder.Data.Generator/Internals/Visibility.cs
@@ -1,0 +1,6 @@
+﻿namespace WoWsShipBuilder.Data.Generator.Internals;
+
+internal enum Visibility
+{
+    Private, Protected, Internal, Public,
+}

--- a/WoWsShipBuilder.Data.Generator/PropertyChangedSourceGenerator.cs
+++ b/WoWsShipBuilder.Data.Generator/PropertyChangedSourceGenerator.cs
@@ -33,7 +33,6 @@ public class PropertyChangedSourceGenerator : IIncrementalGenerator
             return false;
         }
 
-        // var validBaseType = classDeclaration.BaseList?.Types.Any(baseType => baseType.ToString().Contains("ViewModelBase") || baseType.ToString().Contains(nameof(INotifyPropertyChanged))) ?? false;
         return classDeclaration.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.PartialKeyword));
     }
 

--- a/WoWsShipBuilder.Data.Generator/PropertyChangedSourceGenerator.cs
+++ b/WoWsShipBuilder.Data.Generator/PropertyChangedSourceGenerator.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using WoWsShipBuilder.Data.Generator.Internals;
+
+namespace WoWsShipBuilder.Data.Generator;
+
+[Generator]
+public class PropertyChangedSourceGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var viewModels = context.SyntaxProvider.CreateSyntaxProvider(ViewModelFilter, GetViewModelOrNull)
+            .Where(type => type is not null)
+            .Select(GetObservableFields!)
+            .Where(result => result.Items.Count > 0)
+            .Collect();
+        context.RegisterSourceOutput(viewModels, GenerateCode);
+    }
+
+    private static bool ViewModelFilter(SyntaxNode syntaxNode, CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+        if (syntaxNode is not ClassDeclarationSyntax classDeclaration)
+        {
+            return false;
+        }
+
+        // var validBaseType = classDeclaration.BaseList?.Types.Any(baseType => baseType.ToString().Contains("ViewModelBase") || baseType.ToString().Contains(nameof(INotifyPropertyChanged))) ?? false;
+        return classDeclaration.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.PartialKeyword));
+    }
+
+    private static ITypeSymbol? GetViewModelOrNull(GeneratorSyntaxContext context, CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+        var typeDeclaration = (TypeDeclarationSyntax)context.Node;
+        return context.SemanticModel.GetDeclaredSymbol(typeDeclaration);
+    }
+
+    private static SourceGenFilterResult GetObservableFields(ITypeSymbol symbol, CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+        string className = symbol.Name;
+        string classNamespace = symbol.ContainingNamespace.ToDisplayString();
+        List<IFieldSymbol> fields = symbol.GetMembers().OfType<IFieldSymbol>().Where(field => field.GetAttributes().Any(attr => attr.AttributeClass!.Name == "ObservableAttribute")).ToList();
+        return new(className, classNamespace, fields);
+    }
+
+    private static void GenerateCode(SourceProductionContext context, ImmutableArray<SourceGenFilterResult> viewmodels)
+    {
+        var logMessages = new StringBuilder();
+        foreach (var viewmodel in viewmodels)
+        {
+            var classStart = $@"
+using ReactiveUI;
+
+namespace {viewmodel.ElementNamespace};
+
+#nullable enable
+public partial class {viewmodel.ElementName}
+{{
+";
+            const string classEnd = @"
+}
+#nullable restore
+";
+
+            var classBuilder = new StringBuilder(classStart);
+            foreach (var field in viewmodel.Items)
+            {
+                var propertyName = char.ToUpper(field.Name.First()) + field.Name.Substring(1);
+                var fieldAttribute = field.GetAttributes().First(a => a.AttributeClass!.Name == "ObservableAttribute");
+                var setterVisibility = (Visibility)(fieldAttribute.NamedArguments.FirstOrDefault(arg => arg.Key == "SetterVisibility").Value.Value ?? Visibility.Public);
+                var setterVisibilityString = setterVisibility switch
+                {
+                    Visibility.Public => string.Empty,
+                    Visibility.Protected => "protected ",
+                    Visibility.Internal => "internal ",
+                    Visibility.Private => "private ",
+                    _ => throw new InvalidOperationException(),
+                };
+                logMessages.AppendLine("#4");
+                classBuilder.AppendLine($@"
+    public {field.Type} {propertyName}
+    {{
+        get => this.{field.Name};
+        {setterVisibilityString}set => this.RaiseAndSetIfChanged(ref this.{field.Name}, value);
+    }}");
+            }
+
+            classBuilder.AppendLine(classEnd);
+            context.AddSource($"{viewmodel.ElementName}.g.cs", SourceText.From(classBuilder.ToString(), Encoding.UTF8));
+        }
+    }
+
+    private record struct SourceGenFilterResult(string ElementName, string ElementNamespace, List<IFieldSymbol> Items);
+}

--- a/WoWsShipBuilder.ViewModels/Helper/BuildCreationWindowViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/Helper/BuildCreationWindowViewModel.cs
@@ -9,7 +9,7 @@ using WoWsShipBuilder.ViewModels.Base;
 
 namespace WoWsShipBuilder.ViewModels.Helper;
 
-public class BuildCreationWindowViewModel : ViewModelBase
+public partial class BuildCreationWindowViewModel : ViewModelBase
 {
     private const string BuildNameRegex = "^[a-zA-Z0-9][a-zA-Z0-9_ -]*$";
 
@@ -25,13 +25,8 @@ public class BuildCreationWindowViewModel : ViewModelBase
         SaveAndCopyImageCommand = ReactiveCommand.CreateFromTask(SaveAndCopyImage, canSaveExecute);
     }
 
+    [Observable]
     private string shipName = default!;
-
-    public string ShipName
-    {
-        get => shipName;
-        set => this.RaiseAndSetIfChanged(ref shipName, value);
-    }
 
     private string? buildName;
 
@@ -42,13 +37,8 @@ public class BuildCreationWindowViewModel : ViewModelBase
         set => this.RaiseAndSetIfChanged(ref buildName, value);
     }
 
+    [Observable]
     private bool includeSignals;
-
-    public bool IncludeSignals
-    {
-        get => includeSignals;
-        set => this.RaiseAndSetIfChanged(ref includeSignals, value);
-    }
 
     public bool IsNewBuild { get; }
 

--- a/WoWsShipBuilder.ViewModels/Helper/BuildImportViewModelBase.cs
+++ b/WoWsShipBuilder.ViewModels/Helper/BuildImportViewModelBase.cs
@@ -9,7 +9,7 @@ using WoWsShipBuilder.ViewModels.Base;
 
 namespace WoWsShipBuilder.ViewModels.Helper;
 
-public class BuildImportViewModelBase : ViewModelBase
+public partial class BuildImportViewModelBase : ViewModelBase
 {
     protected BuildImportViewModelBase()
     {
@@ -19,21 +19,11 @@ public class BuildImportViewModelBase : ViewModelBase
 
     public ReactiveCommand<Unit, Unit> ImportCommand { get; }
 
+    [Observable]
     private bool importOnly = true;
 
-    public bool ImportOnly
-    {
-        get => importOnly;
-        set => this.RaiseAndSetIfChanged(ref importOnly, value);
-    }
-
+    [Observable]
     private string? buildString;
-
-    public string? BuildString
-    {
-        get => buildString;
-        set => this.RaiseAndSetIfChanged(ref buildString, value);
-    }
 
     public Interaction<Build?, Unit> CloseInteraction { get; } = new();
 

--- a/WoWsShipBuilder.ViewModels/Helper/ValueSelectionViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/Helper/ValueSelectionViewModel.cs
@@ -1,75 +1,52 @@
 using System;
-using System.Collections.Generic;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Threading.Tasks;
 using System.Windows.Input;
 using ReactiveUI;
 using WoWsShipBuilder.ViewModels.Base;
 
-namespace WoWsShipBuilder.ViewModels.Helper
+namespace WoWsShipBuilder.ViewModels.Helper;
+
+public partial class ValueSelectionViewModel : ViewModelBase
 {
-    public class ValueSelectionViewModel : ViewModelBase
+    public ValueSelectionViewModel()
+        : this("Test", "Placeholder", new() { "item1", "item2" })
     {
-        public ValueSelectionViewModel()
-            : this("Test", "Placeholder", new() { "item1", "item2" })
-        {
-        }
+    }
 
-        public ValueSelectionViewModel(string text, string itemPlaceholderText, List<string> items)
-        {
-            Text = text;
-            ItemPlaceholderText = itemPlaceholderText;
-            Items = items;
+    public ValueSelectionViewModel(string text, string itemPlaceholderText, List<string> items)
+    {
+        Text = text;
+        ItemPlaceholderText = itemPlaceholderText;
+        Items = items;
 
-            IObservable<bool> canOkExecute = this.WhenAnyValue(x => x.SelectedItem, selector: selected => selected != null);
-            OkCommand = ReactiveCommand.CreateFromTask(Ok, canOkExecute);
-        }
+        IObservable<bool> canOkExecute = this.WhenAnyValue(x => x.SelectedItem, selector: selected => selected != null);
+        OkCommand = ReactiveCommand.CreateFromTask(Ok, canOkExecute);
+    }
 
-        private string text = default!;
+    [Observable]
+    private string text = default!;
 
-        public string Text
-        {
-            get => text;
-            set => this.RaiseAndSetIfChanged(ref text, value);
-        }
+    [Observable]
+    private string itemPlaceholderText = default!;
 
-        private string itemPlaceholderText = default!;
+    [Observable]
+    private List<string> items = new();
 
-        public string ItemPlaceholderText
-        {
-            get => itemPlaceholderText;
-            set => this.RaiseAndSetIfChanged(ref itemPlaceholderText, value);
-        }
+    [Observable]
+    private string? selectedItem;
 
-        private List<string> items = new();
+    public Interaction<string?, Unit> ConfirmationInteraction { get; } = new();
 
-        public List<string> Items
-        {
-            get => items;
-            set => this.RaiseAndSetIfChanged(ref items, value);
-        }
+    public ICommand OkCommand { get; }
 
-        private string? selectedItem;
+    private async Task Ok()
+    {
+        await ConfirmationInteraction.Handle(SelectedItem);
+    }
 
-        public string? SelectedItem
-        {
-            get => selectedItem;
-            set => this.RaiseAndSetIfChanged(ref selectedItem, value);
-        }
-
-        public Interaction<string?, Unit> ConfirmationInteraction { get; } = new();
-
-        public ICommand OkCommand { get; }
-
-        private async Task Ok()
-        {
-            await ConfirmationInteraction.Handle(SelectedItem);
-        }
-
-        public async void Cancel()
-        {
-            await ConfirmationInteraction.Handle(null);
-        }
+    public async void Cancel()
+    {
+        await ConfirmationInteraction.Handle(null);
     }
 }

--- a/WoWsShipBuilder.ViewModels/ObservableAttribute.cs
+++ b/WoWsShipBuilder.ViewModels/ObservableAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace WoWsShipBuilder.ViewModels;
+
+[AttributeUsage(AttributeTargets.Field)]
+public class ObservableAttribute : Attribute
+{
+    public enum Visibility
+    {
+        Private, Protected, Internal, Public,
+    }
+
+    public Visibility SetterVisibility { get; set; } = Visibility.Public;
+
+    public string[]? Dependants { get; set; }
+}

--- a/WoWsShipBuilder.ViewModels/Other/ShipBuildViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/Other/ShipBuildViewModel.cs
@@ -1,5 +1,4 @@
-﻿using ReactiveUI;
-using WoWsShipBuilder.Core.Builds;
+﻿using WoWsShipBuilder.Core.Builds;
 using WoWsShipBuilder.Core.Data;
 using WoWsShipBuilder.Core.DataContainers;
 using WoWsShipBuilder.Core.DataProvider;
@@ -14,10 +13,12 @@ namespace WoWsShipBuilder.ViewModels.Other;
 /// Based on the structure of the main ship viewmodel, this viewmodel is a simplified version that does not contain a viewmodel to automatically calculate ship stats.
 /// Instead, it allows to manually calculate ship stats based on current modifications.
 /// </summary>
-public class ShipBuildViewModel : ViewModelBase
+public partial class ShipBuildViewModel : ViewModelBase
 {
+    [Observable]
     private string buildName = string.Empty;
 
+    [Observable]
     private bool specialAbilityActive;
 
     private ShipBuildViewModel(Ship ship)
@@ -36,18 +37,6 @@ public class ShipBuildViewModel : ViewModelBase
     public SignalSelectorViewModel SignalSelectorViewModel { get; private init; } = default!;
 
     public Ship CurrentShip { get; }
-
-    public bool SpecialAbilityActive
-    {
-        get => specialAbilityActive;
-        set => this.RaiseAndSetIfChanged(ref specialAbilityActive, value);
-    }
-
-    public string BuildName
-    {
-        get => buildName;
-        set => this.RaiseAndSetIfChanged(ref buildName, value);
-    }
 
     public static ShipBuildViewModel Create(ShipBuildContainer shipBuildContainer)
     {

--- a/WoWsShipBuilder.ViewModels/Other/ShipComparisonViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/Other/ShipComparisonViewModel.cs
@@ -13,7 +13,7 @@ using WoWsShipBuilder.ViewModels.Helper;
 
 namespace WoWsShipBuilder.ViewModels.Other;
 
-public class ShipComparisonViewModel : ViewModelBase
+public partial class ShipComparisonViewModel : ViewModelBase
 {
     public const string DataNotAvailable = "N/A";
 
@@ -72,53 +72,23 @@ public class ShipComparisonViewModel : ViewModelBase
         }
     }
 
+    [Observable]
     private string searchString = default!;
 
-    public string SearchString
-    {
-        get => searchString;
-        set => this.RaiseAndSetIfChanged(ref searchString, value);
-    }
-
+    [Observable]
     private bool showPinnedShipsOnly;
 
-    public bool ShowPinnedShipsOnly
-    {
-        get => showPinnedShipsOnly;
-        private set => this.RaiseAndSetIfChanged(ref showPinnedShipsOnly, value);
-    }
-
+    [Observable]
     private bool pinAllShips;
 
-    public bool PinAllShips
-    {
-        get => pinAllShips;
-        private set => this.RaiseAndSetIfChanged(ref pinAllShips, value);
-    }
-
+    [Observable]
     private bool selectAllShips;
 
-    public bool SelectAllShips
-    {
-        get => selectAllShips;
-        private set => this.RaiseAndSetIfChanged(ref selectAllShips, value);
-    }
-
+    [Observable]
     private bool useUpgradedModules;
 
-    public bool UseUpgradedModules
-    {
-        get => useUpgradedModules;
-        set => this.RaiseAndSetIfChanged(ref useUpgradedModules, value);
-    }
-
+    [Observable]
     private bool hideShipsWithoutSelectedSection;
-
-    public bool HideShipsWithoutSelectedSection
-    {
-        get => hideShipsWithoutSelectedSection;
-        set => this.RaiseAndSetIfChanged(ref hideShipsWithoutSelectedSection, value);
-    }
 
     public ShipComparisonViewModel(ILocalizer localizer, AppSettings appSettings)
     {

--- a/WoWsShipBuilder.ViewModels/Other/SplashScreenViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/Other/SplashScreenViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using NLog;
-using ReactiveUI;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.DataProvider.Updater;
 using WoWsShipBuilder.Core.Localization;
@@ -10,7 +9,7 @@ using WoWsShipBuilder.ViewModels.Base;
 
 namespace WoWsShipBuilder.ViewModels.Other;
 
-public class SplashScreenViewModel : ViewModelBase
+public partial class SplashScreenViewModel : ViewModelBase
 {
     private const int TaskNumber = 4;
 
@@ -24,7 +23,11 @@ public class SplashScreenViewModel : ViewModelBase
 
     private readonly ILogger logger;
 
+    [Observable]
     private double progress;
+
+    [Observable]
+    private string downloadInfo = nameof(Translation.SplashScreen_Init);
 
     public SplashScreenViewModel()
         : this(null!, null!, null!, new())
@@ -38,20 +41,6 @@ public class SplashScreenViewModel : ViewModelBase
         this.appDataService = appDataService;
         this.appSettings = appSettings;
         logger = Logging.GetLogger("SplashScreen");
-    }
-
-    public double Progress
-    {
-        get => progress;
-        set => this.RaiseAndSetIfChanged(ref progress, value);
-    }
-
-    private string downloadInfo = nameof(Translation.SplashScreen_Init);
-
-    public string DownloadInfo
-    {
-        get => downloadInfo;
-        set => this.RaiseAndSetIfChanged(ref downloadInfo, value);
     }
 
     public async Task VersionCheck(bool forceVersionCheck = false, bool throwOnException = false)

--- a/WoWsShipBuilder.ViewModels/ShipVm/CaptainSkillSelectorViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/CaptainSkillSelectorViewModel.cs
@@ -11,7 +11,7 @@ using WoWsShipBuilder.ViewModels.Base;
 
 namespace WoWsShipBuilder.ViewModels.ShipVm;
 
-public class CaptainSkillSelectorViewModel : ViewModelBase
+public partial class CaptainSkillSelectorViewModel : ViewModelBase
 {
     private const int ArSkillNumber = 23;
 
@@ -125,38 +125,14 @@ public class CaptainSkillSelectorViewModel : ViewModelBase
         }
     }
 
+    [Observable]
     private List<Captain>? captainList;
 
-    /// <summary>
-    /// Gets or sets the list of available captains.
-    /// </summary>
-    public List<Captain>? CaptainList
-    {
-        get => captainList;
-        set => this.RaiseAndSetIfChanged(ref captainList, value);
-    }
-
+    [Observable]
     private int assignedPoints;
 
-    /// <summary>
-    /// Gets or sets the number of assigned skill points.
-    /// </summary>
-    public int AssignedPoints
-    {
-        get => assignedPoints;
-        set => this.RaiseAndSetIfChanged(ref assignedPoints, value);
-    }
-
+    [Observable]
     private Dictionary<string, SkillItemViewModel>? skillList;
-
-    /// <summary>
-    /// Gets or sets the dictionary of skillList.
-    /// </summary>
-    public Dictionary<string, SkillItemViewModel>? SkillList
-    {
-        get => skillList;
-        set => this.RaiseAndSetIfChanged(ref skillList, value);
-    }
 
     /// <summary>
     /// Gets the List containing the selected skill in the order they were selected.
@@ -178,16 +154,8 @@ public class CaptainSkillSelectorViewModel : ViewModelBase
         }
     }
 
+    [Observable]
     private int arHpPercentage = 100;
-
-    /// <summary>
-    /// Gets or sets the current Adrenaline rush hp percentage.
-    /// </summary>
-    public int ArHpPercentage
-    {
-        get => arHpPercentage;
-        set => this.RaiseAndSetIfChanged(ref arHpPercentage, value);
-    }
 
     /// <summary>
     /// Gets the dictionary containing the conditional modifiers and their activation status.
@@ -214,38 +182,14 @@ public class CaptainSkillSelectorViewModel : ViewModelBase
         }
     }
 
+    [Observable]
     private bool skillActivationButtonEnabled;
 
-    /// <summary>
-    /// Gets or sets a value indicating whether the skill activation button is enabled.
-    /// </summary>
-    public bool SkillActivationButtonEnabled
-    {
-        get => skillActivationButtonEnabled;
-        set => this.RaiseAndSetIfChanged(ref skillActivationButtonEnabled, value);
-    }
-
+    [Observable]
     private bool talentOrConditionalSkillEnabled;
 
-    /// <summary>
-    /// Gets or sets a value indicating whether a talent or a conditional skill are enabled.
-    /// </summary>
-    public bool TalentOrConditionalSkillEnabled
-    {
-        get => talentOrConditionalSkillEnabled;
-        set => this.RaiseAndSetIfChanged(ref talentOrConditionalSkillEnabled, value);
-    }
-
+    [Observable]
     private bool captainWithTalents;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the current captain has talents.
-    /// </summary>
-    public bool CaptainWithTalents
-    {
-        get => captainWithTalents;
-        set => this.RaiseAndSetIfChanged(ref captainWithTalents, value);
-    }
 
     public bool ScreenshotMode { get; }
 

--- a/WoWsShipBuilder.ViewModels/ShipVm/FiringAngleViewModelBase.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/FiringAngleViewModelBase.cs
@@ -1,83 +1,57 @@
-using ReactiveUI;
 using WoWsShipBuilder.Core.Localization;
 using WoWsShipBuilder.DataStructures.Ship.Components;
 using WoWsShipBuilder.ViewModels.Base;
 
-namespace WoWsShipBuilder.ViewModels.ShipVm
+namespace WoWsShipBuilder.ViewModels.ShipVm;
+
+public partial class FiringAngleViewModelBase : ViewModelBase
 {
-    public class FiringAngleViewModelBase : ViewModelBase
+    [Observable]
+    private IEnumerable<IGun> guns;
+
+    [Observable]
+    private bool permaText = true;
+
+    // TODO: get rid of static translations
+    [Observable]
+    private string permaTextButton = Translation.FiringAngleWindow_PermaTextOff;
+
+    [Observable]
+    private bool showAllText;
+
+    [Observable]
+    private string showAllTextButton = Translation.FiringAngleWindow_ShowAll;
+
+    public FiringAngleViewModelBase(IEnumerable<IGun> guns)
     {
-        private IEnumerable<IGun> guns;
+        this.guns = guns;
+    }
 
-        private bool permaText = true;
-
-        private string permaTextButton = Translation.FiringAngleWindow_PermaTextOff;
-
-        private bool showAllText;
-
-        private string showAllTextButton = Translation.FiringAngleWindow_ShowAll;
-
-        public FiringAngleViewModelBase(IEnumerable<IGun> guns)
+    public void SetShowAll()
+    {
+        if (ShowAllText)
         {
-            this.guns = guns;
+            ShowAllText = false;
+            ShowAllTextButton = Translation.FiringAngleWindow_ShowAll;
         }
-
-        public IEnumerable<IGun> Guns
+        else
         {
-            get => guns;
-            set => this.RaiseAndSetIfChanged(ref guns, value);
+            ShowAllText = true;
+            ShowAllTextButton = Translation.FiringAngleWindow_HideAll;
         }
+    }
 
-        public bool ShowAllText
+    public void SetPermaText()
+    {
+        if (PermaText)
         {
-            get => showAllText;
-            set => this.RaiseAndSetIfChanged(ref showAllText, value);
+            PermaText = false;
+            PermaTextButton = Translation.FiringAngleWindow_PermaTextOn;
         }
-
-        public string ShowAllTextButton
+        else
         {
-            get => showAllTextButton;
-            set => this.RaiseAndSetIfChanged(ref showAllTextButton, value);
-        }
-
-        public bool PermaText
-        {
-            get => permaText;
-            set => this.RaiseAndSetIfChanged(ref permaText, value);
-        }
-
-        public string PermaTextButton
-        {
-            get => permaTextButton;
-            set => this.RaiseAndSetIfChanged(ref permaTextButton, value);
-        }
-
-        public void SetShowAll()
-        {
-            if (ShowAllText)
-            {
-                ShowAllText = false;
-                ShowAllTextButton = Translation.FiringAngleWindow_ShowAll;
-            }
-            else
-            {
-                ShowAllText = true;
-                ShowAllTextButton = Translation.FiringAngleWindow_HideAll;
-            }
-        }
-
-        public void SetPermaText()
-        {
-            if (PermaText)
-            {
-                PermaText = false;
-                PermaTextButton = Translation.FiringAngleWindow_PermaTextOn;
-            }
-            else
-            {
-                PermaText = true;
-                PermaTextButton = Translation.FiringAngleWindow_PermaTextOff;
-            }
+            PermaText = true;
+            PermaTextButton = Translation.FiringAngleWindow_PermaTextOff;
         }
     }
 }

--- a/WoWsShipBuilder.ViewModels/ShipVm/SkillActivationItemViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/SkillActivationItemViewModel.cs
@@ -1,52 +1,34 @@
-using System.Collections.Generic;
-using ReactiveUI;
 using WoWsShipBuilder.ViewModels.Base;
 
-namespace WoWsShipBuilder.ViewModels.ShipVm
+namespace WoWsShipBuilder.ViewModels.ShipVm;
+
+public partial class SkillActivationItemViewModel : ViewModelBase
 {
-    public class SkillActivationItemViewModel : ViewModelBase
+    public SkillActivationItemViewModel(string name, int skillId, Dictionary<string, float> modifiers, bool activationStatus, int maximumActivations = 0, int activationNumbers = 1, string description = "")
     {
-        public SkillActivationItemViewModel(string name, int skillId, Dictionary<string, float> modifiers, bool activationStatus, int maximumActivations = 0, int activationNumbers = 1, string description = "")
-        {
-            SkillName = name;
-            Status = activationStatus;
-            SkillId = skillId;
-            MaximumActivations = maximumActivations;
-            ActivationNumbers = activationNumbers;
-            Modifiers = modifiers;
-            Description = description;
-        }
-
-        private string skillName = default!;
-
-        public string SkillName
-        {
-            get => skillName;
-            set => this.RaiseAndSetIfChanged(ref skillName, value);
-        }
-
-        private bool status;
-
-        public bool Status
-        {
-            get => status;
-            set => this.RaiseAndSetIfChanged(ref status, value);
-        }
-
-        private int activationNumbers;
-
-        public int ActivationNumbers
-        {
-            get => activationNumbers;
-            set => this.RaiseAndSetIfChanged(ref activationNumbers, value);
-        }
-
-        public Dictionary<string, float> Modifiers { get; } = new();
-
-        public int SkillId { get; }
-
-        public int MaximumActivations { get; }
-
-        public string Description { get; }
+        SkillName = name;
+        Status = activationStatus;
+        SkillId = skillId;
+        MaximumActivations = maximumActivations;
+        ActivationNumbers = activationNumbers;
+        Modifiers = modifiers;
+        Description = description;
     }
+
+    [Observable]
+    private string skillName = default!;
+
+    [Observable]
+    private bool status;
+
+    [Observable]
+    private int activationNumbers;
+
+    public Dictionary<string, float> Modifiers { get; }
+
+    public int SkillId { get; }
+
+    public int MaximumActivations { get; }
+
+    public string Description { get; }
 }

--- a/WoWsShipBuilder.ViewModels/ShipVm/SkillItemViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/SkillItemViewModel.cs
@@ -2,126 +2,125 @@
 using WoWsShipBuilder.DataStructures.Captain;
 using WoWsShipBuilder.ViewModels.Base;
 
-namespace WoWsShipBuilder.ViewModels.ShipVm
+namespace WoWsShipBuilder.ViewModels.ShipVm;
+
+public class SkillItemViewModel : ViewModelBase
 {
-    public class SkillItemViewModel : ViewModelBase
+    private readonly CaptainSkillSelectorViewModel parent;
+
+    private bool canExecute;
+
+    private readonly ShipClass shipClass;
+
+    private readonly Dictionary<int, bool> canAddCache;
+
+    private readonly Dictionary<int, bool> canRemoveCache;
+
+    // TODO: update to new nullability state
+    public SkillItemViewModel(Skill skill, CaptainSkillSelectorViewModel parent, ShipClass shipClass, Dictionary<int, bool> canAddCache, Dictionary<int, bool> canRemoveCache)
     {
-        private readonly CaptainSkillSelectorViewModel parent;
-
-        private bool canExecute;
-
-        private readonly ShipClass shipClass;
-
-        private readonly Dictionary<int, bool> canAddCache;
-
-        private readonly Dictionary<int, bool> canRemoveCache;
-
-        // TODO: update to new nullability state
-        public SkillItemViewModel(Skill skill, CaptainSkillSelectorViewModel parent, ShipClass shipClass, Dictionary<int, bool> canAddCache, Dictionary<int, bool> canRemoveCache)
+        Skill = skill;
+        SkillTier = skill.Tiers.First(x => x.ShipClass == shipClass).Tier;
+        SkillXPosition = skill.Tiers.First(x => x.ShipClass == shipClass).XPosition;
+        this.canAddCache = canAddCache;
+        this.canRemoveCache = canRemoveCache;
+        if (skill.Modifiers is not null)
         {
-            Skill = skill;
-            SkillTier = skill.Tiers.First(x => x.ShipClass == shipClass).Tier;
-            SkillXPosition = skill.Tiers.First(x => x.ShipClass == shipClass).XPosition;
-            this.canAddCache = canAddCache;
-            this.canRemoveCache = canRemoveCache;
-            if (skill.Modifiers is not null)
-            {
-                Modifiers = skill.Modifiers.Where(x => !x.Key.Contains('_') || x.Key.Contains("_" + shipClass)).ToDictionary(x => x.Key, x => x.Value);
-            }
-
-            if (skill.ConditionalModifiers is not null)
-            {
-                ConditionalModifiers = skill.ConditionalModifiers.Where(x => !x.Key.Contains('_') || x.Key.Contains("_" + shipClass)).ToDictionary(x => x.Key, x => x.Value);
-            }
-            this.shipClass = shipClass;
-            this.parent = parent;
-            CanExecuteChanged();
+            Modifiers = skill.Modifiers.Where(x => !x.Key.Contains('_') || x.Key.Contains("_" + shipClass)).ToDictionary(x => x.Key, x => x.Value);
         }
 
-
-        public Skill Skill { get; }
-
-        public int SkillTier { get; }
-
-        public int SkillXPosition { get; }
-
-        public Dictionary<string, float> Modifiers { get; } = new();
-
-        public Dictionary<string, float> ConditionalModifiers { get; } = new();
-
-        public bool CanExecute
+        if (skill.ConditionalModifiers is not null)
         {
-            get => canExecute;
-            set => this.RaiseAndSetIfChanged(ref canExecute, value);
+            ConditionalModifiers = skill.ConditionalModifiers.Where(x => !x.Key.Contains('_') || x.Key.Contains("_" + shipClass)).ToDictionary(x => x.Key, x => x.Value);
+        }
+        this.shipClass = shipClass;
+        this.parent = parent;
+        CanExecuteChanged();
+    }
+
+
+    public Skill Skill { get; }
+
+    public int SkillTier { get; }
+
+    public int SkillXPosition { get; }
+
+    public Dictionary<string, float> Modifiers { get; } = new();
+
+    public Dictionary<string, float> ConditionalModifiers { get; } = new();
+
+    public bool CanExecute
+    {
+        get => canExecute;
+        set => this.RaiseAndSetIfChanged(ref canExecute, value);
+    }
+
+    public void CanExecuteChanged()
+    {
+        bool result;
+
+        // Can add skill
+        if (!parent.SkillOrderList.Contains(Skill))
+        {
+            if (canAddCache.TryGetValue(SkillTier, out bool canAdd))
+            {
+                CanExecute = canAdd;
+                return;
+            }
+
+            // If the points would go over 21, can't add the skill
+            if (parent.AssignedPoints + SkillTier + 1 > 21)
+            {
+                result = false;
+            }
+
+            // If it's a skill of the first tier, i can always add it
+            else if (SkillTier == 0)
+            {
+                result = true;
+            }
+            else
+            {
+                // If it's not, i search the skill of the previous tier. If at least one exist, i can add it
+                result = parent.SkillOrderList.Select(s => s.Tiers.First(x => x.ShipClass == shipClass).Tier).Any(cost => cost == SkillTier - 1);
+            }
+
+            canAddCache[SkillTier] = result;
         }
 
-        public void CanExecuteChanged()
+        // Can remove skill
+        else
         {
-            bool result;
-
-            // Can add skill
-            if (!parent.SkillOrderList.Contains(Skill))
+            // If the skill tier is 4 (tier 3, since our index start from 0), can always remove
+            if (SkillTier == 3)
             {
-                if (canAddCache.TryGetValue(SkillTier, out bool canAdd))
+                result = true;
+            }
+            else
+            {
+                if (canRemoveCache.TryGetValue(SkillTier, out bool canRemove))
                 {
-                    CanExecute = canAdd;
+                    CanExecute = canRemove;
                     return;
                 }
 
-                // If the points would go over 21, can't add the skill
-                if (parent.AssignedPoints + SkillTier + 1 > 21)
-                {
-                    result = false;
-                }
+                List<int> skillTiers = parent.SkillOrderList.Select(iteratedSkill => iteratedSkill.Tiers.First(x => x.ShipClass == shipClass).Tier).ToList();
+                int nextTierSkillCount = skillTiers.Count(skillCost => skillCost > SkillTier);
+                int sameTierSkillCount = skillTiers.Count(skillCost => skillCost == SkillTier);
 
-                // If it's a skill of the first tier, i can always add it
-                else if (SkillTier == 0)
+                if (nextTierSkillCount > 0)
                 {
-                    result = true;
+                    result = sameTierSkillCount > 1;
                 }
                 else
                 {
-                    // If it's not, i search the skill of the previous tier. If at least one exist, i can add it
-                    result = parent.SkillOrderList.Select(s => s.Tiers.First(x => x.ShipClass == shipClass).Tier).Any(cost => cost == SkillTier - 1);
-                }
-
-                canAddCache[SkillTier] = result;
-            }
-
-            // Can remove skill
-            else
-            {
-                // If the skill tier is 4 (tier 3, since our index start from 0), can always remove
-                if (SkillTier == 3)
-                {
                     result = true;
                 }
-                else
-                {
-                    if (canRemoveCache.TryGetValue(SkillTier, out bool canRemove))
-                    {
-                        CanExecute = canRemove;
-                        return;
-                    }
 
-                    List<int> skillTiers = parent.SkillOrderList.Select(iteratedSkill => iteratedSkill.Tiers.First(x => x.ShipClass == shipClass).Tier).ToList();
-                    int nextTierSkillCount = skillTiers.Count(skillCost => skillCost > SkillTier);
-                    int sameTierSkillCount = skillTiers.Count(skillCost => skillCost == SkillTier);
-
-                    if (nextTierSkillCount > 0)
-                    {
-                        result = sameTierSkillCount > 1;
-                    }
-                    else
-                    {
-                        result = true;
-                    }
-
-                    canRemoveCache[SkillTier] = result;
-                }
+                canRemoveCache[SkillTier] = result;
             }
-
-            CanExecute = result;
         }
+
+        CanExecute = result;
     }
 }

--- a/WoWsShipBuilder.ViewModels/ShipVm/UpgradePanelViewModelBase.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/UpgradePanelViewModelBase.cs
@@ -7,92 +7,91 @@ using WoWsShipBuilder.DataStructures.Ship;
 using WoWsShipBuilder.DataStructures.Upgrade;
 using WoWsShipBuilder.ViewModels.Base;
 
-namespace WoWsShipBuilder.ViewModels.ShipVm
+namespace WoWsShipBuilder.ViewModels.ShipVm;
+
+public class UpgradePanelViewModelBase : ViewModelBase, IBuildComponentProvider
 {
-    public class UpgradePanelViewModelBase : ViewModelBase, IBuildComponentProvider
+    public static readonly Modernization PlaceholderModernization = new() { Index = null!, Name = "PlaceholderMod" };
+
+    private List<List<Modernization>> availableModernizationList = null!;
+
+    public UpgradePanelViewModelBase(Ship ship, Dictionary<string, Modernization> upgradeData)
     {
-        public static readonly Modernization PlaceholderModernization = new() { Index = null!, Name = "PlaceholderMod" };
+        List<Modernization> filteredModernizations = upgradeData.Select(entry => entry.Value)
+            .Where(m => !(m.BlacklistedShips.Contains(ship.Name)))
+            .Where(m => m.ShipLevel.Contains(ship.Tier))
+            .Where(m => ship.ShipNation == Nation.Common || (m.AllowedNations.Contains(ship.ShipNation)))
+            .Where(m => m.ShipClasses.Contains(ship.ShipClass))
+            .Union(upgradeData.Select(entry => entry.Value).Where(m => m.AdditionalShips.Contains(ship.Name)))
+            .ToList();
 
-        private List<List<Modernization>> availableModernizationList = null!;
+        List<List<Modernization>> groupedList = filteredModernizations.GroupBy(m => m.Slot)
+            .Select(group => (group.Key, group.OrderBy(m => m.Type).ThenBy(m => m.Index).ToList()))
+            .OrderBy(item => item.Key)
+            .Select(item => item.Item2)
+            .ToList();
 
-        public UpgradePanelViewModelBase(Ship ship, Dictionary<string, Modernization> upgradeData)
+        foreach (List<Modernization> subList in groupedList)
         {
-            List<Modernization> filteredModernizations = upgradeData.Select(entry => entry.Value)
-                .Where(m => !(m.BlacklistedShips.Contains(ship.Name)))
-                .Where(m => m.ShipLevel.Contains(ship.Tier))
-                .Where(m => ship.ShipNation == Nation.Common || (m.AllowedNations.Contains(ship.ShipNation)))
-                .Where(m => m.ShipClasses.Contains(ship.ShipClass))
-                .Union(upgradeData.Select(entry => entry.Value).Where(m => m.AdditionalShips.Contains(ship.Name)))
-                .ToList();
+            subList.Insert(0, PlaceholderModernization);
+        }
 
-            List<List<Modernization>> groupedList = filteredModernizations.GroupBy(m => m.Slot)
-                .Select(group => (group.Key, group.OrderBy(m => m.Type).ThenBy(m => m.Index).ToList()))
-                .OrderBy(item => item.Key)
-                .Select(item => item.Item2)
-                .ToList();
+        AvailableModernizationList = groupedList;
+        SelectedModernizationList = new(AvailableModernizationList.Select(list => list.First()).Where(m => !string.IsNullOrEmpty(m.Index)));
 
-            foreach (List<Modernization> subList in groupedList)
+        OnModernizationSelected = (modernization, modernizationList) =>
+        {
+            int listIndex = AvailableModernizationList.IndexOf(modernizationList);
+            var oldSelection = SelectedModernizationList.ToList().Find(m => AvailableModernizationList[listIndex].Contains(m));
+
+            if (oldSelection != null)
             {
-                subList.Insert(0, PlaceholderModernization);
+                SelectedModernizationList.Remove(oldSelection);
             }
 
-            AvailableModernizationList = groupedList;
-            SelectedModernizationList = new(AvailableModernizationList.Select(list => list.First()).Where(m => !string.IsNullOrEmpty(m.Index)));
-
-            OnModernizationSelected = (modernization, modernizationList) =>
+            if (modernization?.Index != null)
             {
-                int listIndex = AvailableModernizationList.IndexOf(modernizationList);
-                var oldSelection = SelectedModernizationList.ToList().Find(m => AvailableModernizationList[listIndex].Contains(m));
-
-                if (oldSelection != null)
-                {
-                    SelectedModernizationList.Remove(oldSelection);
-                }
-
-                if (modernization?.Index != null)
-                {
-                    SelectedModernizationList.Add(modernization);
-                }
-
-                this.RaisePropertyChanged(nameof(SelectedModernizationList));
-            };
-        }
-
-        public Action<Modernization?, List<Modernization>> OnModernizationSelected { get; }
-
-        public CustomObservableCollection<Modernization> SelectedModernizationList { get; }
-
-        public List<List<Modernization>> AvailableModernizationList
-        {
-            get => availableModernizationList;
-            set => this.RaiseAndSetIfChanged(ref availableModernizationList, value);
-        }
-
-        public List<(string, float)> GetModifierList()
-        {
-            return SelectedModernizationList
-                .Where(m => !string.IsNullOrEmpty(m.Index))
-                .SelectMany(m => m.Effect.Select(effect => (effect.Key, (float)effect.Value)))
-                .ToList();
-        }
-
-        public void LoadBuild(IEnumerable<string> storedData)
-        {
-            var selection = new List<Modernization>();
-            foreach (List<Modernization> modernizations in AvailableModernizationList)
-            {
-                selection.AddRange(modernizations.Where(modernization => storedData.Contains(modernization.Index)));
+                SelectedModernizationList.Add(modernization);
             }
 
-            var removeList = SelectedModernizationList.Where(selected => selection.Any(newSelected => newSelected.Slot == selected.Slot)).ToList();
-            SelectedModernizationList.RemoveMany(removeList);
-            SelectedModernizationList.AddRange(selection);
             this.RaisePropertyChanged(nameof(SelectedModernizationList));
+        };
+    }
+
+    public Action<Modernization?, List<Modernization>> OnModernizationSelected { get; }
+
+    public CustomObservableCollection<Modernization> SelectedModernizationList { get; }
+
+    public List<List<Modernization>> AvailableModernizationList
+    {
+        get => availableModernizationList;
+        set => this.RaiseAndSetIfChanged(ref availableModernizationList, value);
+    }
+
+    public List<(string, float)> GetModifierList()
+    {
+        return SelectedModernizationList
+            .Where(m => !string.IsNullOrEmpty(m.Index))
+            .SelectMany(m => m.Effect.Select(effect => (effect.Key, (float)effect.Value)))
+            .ToList();
+    }
+
+    public void LoadBuild(IEnumerable<string> storedData)
+    {
+        var selection = new List<Modernization>();
+        foreach (List<Modernization> modernizations in AvailableModernizationList)
+        {
+            selection.AddRange(modernizations.Where(modernization => storedData.Contains(modernization.Index)));
         }
 
-        public List<string> SaveBuild()
-        {
-            return SelectedModernizationList.Select(modernization => modernization.Index).ToList();
-        }
+        var removeList = SelectedModernizationList.Where(selected => selection.Any(newSelected => newSelected.Slot == selected.Slot)).ToList();
+        SelectedModernizationList.RemoveMany(removeList);
+        SelectedModernizationList.AddRange(selection);
+        this.RaisePropertyChanged(nameof(SelectedModernizationList));
+    }
+
+    public List<string> SaveBuild()
+    {
+        return SelectedModernizationList.Select(modernization => modernization.Index).ToList();
     }
 }

--- a/WoWsShipBuilder.ViewModels/WoWsShipBuilder.ViewModels.csproj
+++ b/WoWsShipBuilder.ViewModels/WoWsShipBuilder.ViewModels.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\WoWsShipBuilder.Core\WoWsShipBuilder.Core.csproj" />
+      <ProjectReference Include="..\WoWsShipBuilder.Data.Generator\WoWsShipBuilder.Data.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Add simple source generator to generator property accessors for fields that do not need additional, complex logic in their property setters or getters.
This reduces boilerplate code and simplifies adding a property to a viewmodel.