### PR TITLE
Add viewmodels caching to shipstats

### DIFF
--- a/WoWsShipBuilder.Core/DataContainers/Armament/PingerGunDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Armament/PingerGunDataContainer.cs
@@ -23,10 +23,10 @@ namespace WoWsShipBuilder.Core.DataContainers
         [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "KM")]
         public decimal Range { get; set; }
 
-        [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
+        [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue, GroupKey = "PingDuration", UnitKey = "S", NameLocalizationKey = "First")]
         public decimal FirstPingDuration { get; set; }
 
-        [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
+        [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue, GroupKey = "PingDuration", UnitKey = "S", NameLocalizationKey = "Second")]
         public decimal SecondPingDuration { get; set; }
 
         [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "M")]

--- a/WoWsShipBuilder.Core/DataContainers/Armament/TorpedoArmamentDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Armament/TorpedoArmamentDataContainer.cs
@@ -18,6 +18,12 @@ public partial record TorpedoArmamentDataContainer : DataContainerBase
 
     public List<string> LauncherNames { get; set; } = new();
 
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue, GroupKey = "Loaders")]
+    public string BowLoaders { get; set; } = default!;
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue, GroupKey = "Loaders")]
+    public string SternLoaders { get; set; } = default!;
+
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
     public decimal TurnTime { get; set; }
 
@@ -127,6 +133,11 @@ public partial record TorpedoArmamentDataContainer : DataContainerBase
             TorpFullSalvoDmg = torpFullSalvoDmg,
             AltTorpFullSalvoDmg = altTorpFullSalvoDmg,
         };
+
+        torpedoModule.TorpedoLoaders.TryGetValue(SubTorpLauncherLoaderPosition.BowLoaders, out List<string>? bowLoaders);
+        torpedoModule.TorpedoLoaders.TryGetValue(SubTorpLauncherLoaderPosition.SternLoaders, out List<string>? sternLoaders);
+        torpedoArmamentDataContainer.BowLoaders = bowLoaders is not null ? string.Join(" + ", bowLoaders) : default!;
+        torpedoArmamentDataContainer.SternLoaders = sternLoaders is not null ? string.Join(" + ", sternLoaders) : default!;
 
         torpedoArmamentDataContainer.Torpedoes.Last().IsLast = true;
 

--- a/WoWsShipBuilder.Core/DataContainers/ModifierProcessor.cs
+++ b/WoWsShipBuilder.Core/DataContainers/ModifierProcessor.cs
@@ -155,7 +155,7 @@ public static class ModifierProcessor
             case { } str when str.Equals("lifeTime", StringComparison.InvariantCultureIgnoreCase) ||
                               str.Contains("timeFromHeaven", StringComparison.InvariantCultureIgnoreCase) ||
                               str.Contains("torpedoReloadTime", StringComparison.InvariantCultureIgnoreCase) ||
-                              str.Contains("hydrophoneUpdateFrequency", StringComparison.InvariantCultureIgnoreCase):
+                              str.Equals("hydrophoneUpdateFrequency", StringComparison.InvariantCultureIgnoreCase):
                 value = $"{modifier} {localizer.SimpleAppLocalization(nameof(Translation.Unit_S))}";
                 break;
 
@@ -194,8 +194,7 @@ public static class ModifierProcessor
     {
         string prefix = "PARAMS_MODIFIER_";
 
-        if (localizerKey.Contains("regenerationHPSpeedUnits", StringComparison.InvariantCultureIgnoreCase) ||
-            localizerKey.Contains("hydrophoneUpdateFrequencyCoeff", StringComparison.InvariantCultureIgnoreCase))
+        if (localizerKey.Contains("regenerationHPSpeedUnits", StringComparison.InvariantCultureIgnoreCase))
         {
             return string.Empty;
         }
@@ -316,12 +315,10 @@ public static class ModifierProcessor
         {
             return "";
         }
-        else
-        {
-            // Remove [HIDDEN] text from some skills modifiers.
-            description = description.Replace("[HIDDEN]", "");
-            return value + " " + description.Trim();
-        }
+
+        // Remove [HIDDEN] text from some skills modifiers.
+        description = description.Replace("[HIDDEN]", "");
+        return value + " " + description.Trim();
     }
 
     public static string GetUiModifierString(string localizerKey, double modifier, ReturnFilter returnFilter, ILocalizer localizer)

--- a/WoWsShipBuilder.Core/DataContainers/Projectiles/ShellDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Projectiles/ShellDataContainer.cs
@@ -184,6 +184,8 @@ public partial record ShellDataContainer : DataContainerBase
 
             var fireChancePerSalvo = (decimal)(1 - Math.Pow((double)(1 - ((decimal)shellFireChance / 100)), barrelCount));
 
+            float splashRadius = modifiers.FindModifiers("dcSplashRadiusMultiplier").Aggregate(shell.DepthSplashRadius, (current, modifier) => current * modifier);
+
             var shellDataContainer = new ShellDataContainer
             {
                 Name = shell.Name,
@@ -201,7 +203,7 @@ public partial record ShellDataContainer : DataContainerBase
                 ArmingThreshold = armingThreshold,
                 FuseTimer = fuseTimer,
                 ShowBlastPenetration = showBlastPenetration,
-                SplashRadius = (decimal)shell.DepthSplashRadius,
+                SplashRadius = Math.Round((decimal)splashRadius, 1),
                 SplashDmg = Math.Round((decimal)(shellDamage * shell.SplashDamageCoefficient)),
                 Krupp = (decimal)shell.Krupp,
             };

--- a/WoWsShipBuilder.Core/DataContainers/Projectiles/TorpedoDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Projectiles/TorpedoDataContainer.cs
@@ -46,6 +46,72 @@ public partial record TorpedoDataContainer : ProjectileDataContainer
     [DataElementFiltering(false)]
     public decimal SplashCoeff { get; set; }
 
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "MaxTurningSpeed", UnitKey = "MPS", NameLocalizationKey = "FirstPing")]
+    public decimal MaxTurningSpeedFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "MaxTurningSpeed", UnitKey = "MPS", NameLocalizationKey = "SecondPing")]
+    public decimal MaxTurningSpeedSecondPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "TurningAcceleration", UnitKey = "MPS2", NameLocalizationKey = "FirstPing")]
+    public decimal TurningAccelerationFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "TurningAcceleration", UnitKey = "MPS2", NameLocalizationKey = "SecondPing")]
+    public decimal TurningAccelerationSecondPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "MaxVerticalSpeed", UnitKey = "MPS", NameLocalizationKey = "FirstPing")]
+    public decimal MaxVerticalSpeedFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "MaxVerticalSpeed", UnitKey = "MPS", NameLocalizationKey = "SecondPing")]
+    public decimal MaxVerticalSpeedSecondPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "VerticalAcceleration", UnitKey = "MPS2", NameLocalizationKey = "FirstPing")]
+    public decimal VerticalAccelerationFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "VerticalAcceleration", UnitKey = "MPS2", NameLocalizationKey = "SecondPing")]
+    public decimal VerticalAccelerationSecondPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "SearchRadius", UnitKey = "KM", NameLocalizationKey = "FirstPing")]
+    public decimal SearchRadiusFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "SearchRadius", UnitKey = "KM", NameLocalizationKey = "SecondPing")]
+    public decimal SearchRadiusSecondPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "SearchAngle", UnitKey = "Degree", NameLocalizationKey = "FirstPing")]
+    public decimal SearchAngleFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "SearchAngle", UnitKey = "Degree", NameLocalizationKey = "SecondPing")]
+    public decimal SearchAngleSecondPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Destroyer", UnitKey = "M", NameLocalizationKey = "FirstPing")]
+    public decimal DestroyerCutOffFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Destroyer", UnitKey = "M", NameLocalizationKey = "SecondPing")]
+    public decimal DestroyerCutOffSecondPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Battleship", UnitKey = "M", NameLocalizationKey = "FirstPing")]
+    public decimal BattleshipCutOffFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Battleship", UnitKey = "M", NameLocalizationKey = "SecondPing")]
+    public decimal BattleshipCutOffSecondPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Cruiser", UnitKey = "M", NameLocalizationKey = "FirstPing")]
+    public decimal CruiserCutOffFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Cruiser", UnitKey = "M", NameLocalizationKey = "SecondPing")]
+    public decimal CruiserCutOffSecondPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Submarine", UnitKey = "M", NameLocalizationKey = "FirstPing")]
+    public decimal SubCutOffFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Submarine", UnitKey = "M", NameLocalizationKey = "SecondPing")]
+    public decimal SubCutOffSecondPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "AirCarrier", UnitKey = "M", NameLocalizationKey = "FirstPing")]
+    public decimal CvCutOffFirstPing { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "AirCarrier", UnitKey = "M", NameLocalizationKey = "SecondPing")]
+    public decimal CvCutOffSecondPing { get; set; }
+
     public List<ShipClass>? CanHitClasses { get; set; }
 
     public bool IsLast { get; set; }
@@ -92,6 +158,39 @@ public partial record TorpedoDataContainer : ProjectileDataContainer
                 SplashCoeff = (decimal)torp.SplashCoeff,
                 IsFromPlane = fromPlane,
             };
+
+            if (torp.TorpedoType == DataStructures.TorpedoType.Magnetic)
+            {
+                torpedoDataContainer.MaxTurningSpeedFirstPing = Math.Round((decimal)torp.MagneticTorpedoParams.MaxTurningSpeed.First(), 1);
+                torpedoDataContainer.MaxTurningSpeedSecondPing = Math.Round((decimal)torp.MagneticTorpedoParams.MaxTurningSpeed.Last(), 1);
+                torpedoDataContainer.TurningAccelerationFirstPing = Math.Round((decimal)torp.MagneticTorpedoParams.TurningAcceleration.First(), 1);
+                torpedoDataContainer.TurningAccelerationSecondPing = Math.Round((decimal)torp.MagneticTorpedoParams.TurningAcceleration.Last(), 1);
+                torpedoDataContainer.MaxVerticalSpeedFirstPing = Math.Round((decimal)torp.MagneticTorpedoParams.MaxVerticalSpeed.First(), 1);
+                torpedoDataContainer.MaxVerticalSpeedSecondPing = Math.Round((decimal)torp.MagneticTorpedoParams.MaxVerticalSpeed.Last(), 1);
+                torpedoDataContainer.VerticalAccelerationFirstPing = Math.Round((decimal)torp.MagneticTorpedoParams.VerticalAcceleration.First(), 1);
+                torpedoDataContainer.VerticalAccelerationSecondPing = Math.Round((decimal)torp.MagneticTorpedoParams.VerticalAcceleration.Last(), 1);
+                torpedoDataContainer.SearchRadiusFirstPing = Math.Round((decimal)torp.MagneticTorpedoParams.SearchRadius.First(), 1);
+                torpedoDataContainer.SearchRadiusSecondPing = Math.Round((decimal)torp.MagneticTorpedoParams.SearchRadius.Last(), 1);
+                torpedoDataContainer.SearchAngleFirstPing = Math.Round((decimal)torp.MagneticTorpedoParams.SearchAngle.First(), 1);
+                torpedoDataContainer.SearchAngleSecondPing = Math.Round((decimal)torp.MagneticTorpedoParams.SearchAngle.Last(), 1);
+
+                var ddCutOff = torp.MagneticTorpedoParams.DropTargetAtDistance.First(x => x.Key == ShipClass.Destroyer).Value;
+                var bbCutOff = torp.MagneticTorpedoParams.DropTargetAtDistance.First(x => x.Key == ShipClass.Battleship).Value;
+                var caCutOff = torp.MagneticTorpedoParams.DropTargetAtDistance.First(x => x.Key == ShipClass.Cruiser).Value;
+                var subCutOff = torp.MagneticTorpedoParams.DropTargetAtDistance.First(x => x.Key == ShipClass.Submarine).Value;
+                var cvCutOff = torp.MagneticTorpedoParams.DropTargetAtDistance.First(x => x.Key == ShipClass.AirCarrier).Value;
+
+                torpedoDataContainer.DestroyerCutOffFirstPing = Math.Round((decimal)ddCutOff.First(), 1);
+                torpedoDataContainer.DestroyerCutOffSecondPing = Math.Round((decimal)ddCutOff.Last(), 1);
+                torpedoDataContainer.BattleshipCutOffFirstPing = Math.Round((decimal)bbCutOff.First(), 1);
+                torpedoDataContainer.BattleshipCutOffSecondPing = Math.Round((decimal)bbCutOff.Last(), 1);
+                torpedoDataContainer.CruiserCutOffFirstPing = Math.Round((decimal)caCutOff.First(), 1);
+                torpedoDataContainer.CruiserCutOffSecondPing = Math.Round((decimal)caCutOff.Last(), 1);
+                torpedoDataContainer.SubCutOffFirstPing = Math.Round((decimal)subCutOff.First(), 1);
+                torpedoDataContainer.SubCutOffSecondPing = Math.Round((decimal)subCutOff.Last(), 1);
+                torpedoDataContainer.CvCutOffFirstPing = Math.Round((decimal)cvCutOff.First(), 1);
+                torpedoDataContainer.CvCutOffSecondPing = Math.Round((decimal)cvCutOff.Last(), 1);
+            }
 
             if (torp.IgnoreClasses != null && torp.IgnoreClasses.Any())
             {

--- a/WoWsShipBuilder.Core/DataContainers/Projectiles/TorpedoDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Projectiles/TorpedoDataContainer.cs
@@ -46,16 +46,16 @@ public partial record TorpedoDataContainer : ProjectileDataContainer
     [DataElementFiltering(false)]
     public decimal SplashCoeff { get; set; }
 
-    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "MaxTurningSpeed", UnitKey = "MPS", NameLocalizationKey = "FirstPing")]
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "MaxTurningSpeed", UnitKey = "DegreePerSecond", NameLocalizationKey = "FirstPing")]
     public decimal MaxTurningSpeedFirstPing { get; set; }
 
-    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "MaxTurningSpeed", UnitKey = "MPS", NameLocalizationKey = "SecondPing")]
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "MaxTurningSpeed", UnitKey = "DegreePerSecond", NameLocalizationKey = "SecondPing")]
     public decimal MaxTurningSpeedSecondPing { get; set; }
 
-    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "TurningAcceleration", UnitKey = "MPS2", NameLocalizationKey = "FirstPing")]
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "TurningAcceleration", UnitKey = "DegreePerSecond2", NameLocalizationKey = "FirstPing")]
     public decimal TurningAccelerationFirstPing { get; set; }
 
-    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "TurningAcceleration", UnitKey = "MPS2", NameLocalizationKey = "SecondPing")]
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "TurningAcceleration", UnitKey = "DegreePerSecond2", NameLocalizationKey = "SecondPing")]
     public decimal TurningAccelerationSecondPing { get; set; }
 
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "MaxVerticalSpeed", UnitKey = "MPS", NameLocalizationKey = "FirstPing")]

--- a/WoWsShipBuilder.Core/DataContainers/Ship/ConsumableDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Ship/ConsumableDataContainer.cs
@@ -253,13 +253,8 @@ public partial record ConsumableDataContainer : DataContainerBase
             else if (name.Contains("PCY045", StringComparison.InvariantCultureIgnoreCase))
             {
                 var hydrophoneUpdateFrequencyModifiers = modifiers.FindModifiers("hydrophoneUpdateFrequencyCoeff");
-                if (!consumableModifiers.TryGetValue("hydrophoneUpdateFrequencyCoeff", out float baseUpdateFrequency))
-                {
-                    consumableModifiers.TryGetValue("updateFrequency", out baseUpdateFrequency);
-                }
-
-                var hydrophoneUpdateFrequency = hydrophoneUpdateFrequencyModifiers.Aggregate(baseUpdateFrequency, (current, modifier) => current * modifier);
-                consumableModifiers["hydrophoneUpdateFrequencyCoeff"] = hydrophoneUpdateFrequency;
+                var hydrophoneUpdateFrequency = hydrophoneUpdateFrequencyModifiers.Aggregate(consumableModifiers["hydrophoneUpdateFrequency"], (current, modifier) => current * modifier);
+                consumableModifiers["hydrophoneUpdateFrequency"] = hydrophoneUpdateFrequency;
             }
         }
         else if (usingFallback)

--- a/WoWsShipBuilder.Core/DataContainers/Ship/ConsumableDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Ship/ConsumableDataContainer.cs
@@ -24,6 +24,9 @@ public partial record ConsumableDataContainer : DataContainerBase
     public string NumberOfUses { get; set; } = default!;
 
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
+    public decimal PreparationTime { get; set; }
+
+    [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
     public decimal Cooldown { get; set; }
 
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
@@ -272,6 +275,7 @@ public partial record ConsumableDataContainer : DataContainerBase
             Slot = slot,
             Desc = "",
             Cooldown = Math.Round((decimal)cooldown, 1),
+            PreparationTime = Math.Round((decimal)consumable.PreparationTime, 1),
             WorkTime = Math.Round((decimal)workTime, 1),
             Modifiers = consumableModifiers,
         };

--- a/WoWsShipBuilder.Core/DataContainers/Ship/ManeuverabilityDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Ship/ManeuverabilityDataContainer.cs
@@ -23,6 +23,12 @@ public partial record ManeuverabilityDataContainer : DataContainerBase
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "MaxSpeed", UnitKey = "Knots")]
     public decimal ManeuverabilitySubsMaxSpeedAtMaxDepth { get; set; }
 
+    [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "MPS")]
+    public decimal ManeuverabilitySubsMaxDiveSpeed { get; set; }
+
+    [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
+    public decimal ManeuverabilitySubsDivingPlaneShiftTime { get; set; }
+
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
     public decimal ManeuverabilityRudderShiftTime { get; set; }
 
@@ -53,6 +59,10 @@ public partial record ManeuverabilityDataContainer : DataContainerBase
         maxSpeedModifier = modifiers.FindModifiers("shipSpeedCoeff", true).Aggregate(maxSpeedModifier, (current, modifier) => current * (decimal)modifier);
         maxSpeedModifier = modifiers.FindModifiers("boostCoeff").Aggregate(maxSpeedModifier, (current, modifier) => current + (decimal)modifier); // Speed boost is additive
 
+        decimal maxDiveSpeedModifier = modifiers.FindModifiers("maxBuoyancySpeedCoeff", true).Aggregate(1m, (current, modifier) => current * (decimal)modifier);
+
+        decimal divingPlaneShiftTimeModifier = modifiers.FindModifiers("buoyancyRudderTimeCoeff", true).Aggregate(1m, (current, modifier) => current * (decimal)modifier);
+
         decimal enlargedPropellerShaftSpeedModifier = modifiers.FindModifiers("speedCoefBattery", true).Aggregate(1m, (current, modifier) => current * (decimal)modifier);
 
         decimal rudderShiftModifier = modifiers.FindModifiers("SGRudderTime").Aggregate(1m, (current, modifier) => current * (decimal)modifier);
@@ -82,10 +92,12 @@ public partial record ManeuverabilityDataContainer : DataContainerBase
         hull.MaxSpeedAtBuoyancyStateCoeff.TryGetValue(SubsBuoyancyStates.DeepWater, out decimal speedAtMaxDepthCoeff);
 
         decimal maxSpeed = hull.MaxSpeed * (engine.SpeedCoef + 1) * maxSpeedModifier;
-
         decimal maxSpeedOnSurface = 0;
         decimal maxSpeedAtPeriscope = 0;
         decimal maxSpeedAtMaxDepth = 0;
+        decimal maxDiveSpeed = 0;
+
+        decimal divingPlaneShiftTime = 0;
 
         if (ship.ShipClass == ShipClass.Submarine)
         {
@@ -93,6 +105,9 @@ public partial record ManeuverabilityDataContainer : DataContainerBase
             maxSpeedAtPeriscope = maxSpeed * speedAtPeriscopeCoeff * enlargedPropellerShaftSpeedModifier;
             maxSpeedAtMaxDepth = maxSpeed * speedAtMaxDepthCoeff;
             maxSpeed = 0;
+            maxDiveSpeed = hull.DiveSpeed;
+
+            divingPlaneShiftTime = hull.DivingPlaneShiftTime;
         }
 
         var manoeuvrability = new ManeuverabilityDataContainer
@@ -100,10 +115,12 @@ public partial record ManeuverabilityDataContainer : DataContainerBase
             ForwardMaxSpeedTime = Math.Round((decimal)timeForward, 2),
             ReverseMaxSpeedTime = Math.Round((decimal)timeBackward, 2),
             ManeuverabilityMaxSpeed = Math.Round(maxSpeed, 2),
+            ManeuverabilitySubsMaxDiveSpeed = Math.Round(maxDiveSpeed * maxDiveSpeedModifier, 2),
             ManeuverabilitySubsMaxSpeedOnSurface = Math.Round(maxSpeedOnSurface, 2),
             ManeuverabilitySubsMaxSpeedAtPeriscope = Math.Round(maxSpeedAtPeriscope, 2),
             ManeuverabilitySubsMaxSpeedAtMaxDepth = Math.Round(maxSpeedAtMaxDepth, 2),
             ManeuverabilityRudderShiftTime = Math.Round((hull.RudderTime * rudderShiftModifier) / 1.305M, 2),
+            ManeuverabilitySubsDivingPlaneShiftTime = Math.Round(divingPlaneShiftTime * divingPlaneShiftTimeModifier, 2),
             ManeuverabilityTurningCircle = hull.TurningRadius,
             RudderBlastProtection = hull.SteeringGearArmorCoeff,
             EngineBlastProtection = engine.ArmorCoeff,

--- a/WoWsShipBuilder.Core/DataContainers/Ship/SurvivabilityDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Ship/SurvivabilityDataContainer.cs
@@ -58,6 +58,12 @@ namespace WoWsShipBuilder.Core.DataContainers
         [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Hull", UnitKey = "PerCent", NameLocalizationKey = "RegenRatio")]
         public decimal HullRegenRatio { get; set; }
 
+        [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Battery", UnitKey = "U")]
+        public decimal DiveCapacity { get; set; }
+
+        [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Battery", UnitKey = "UPS")]
+        public decimal DiveCapacityRechargeRate { get; set; }
+
         [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue, GroupKey = "Fire")]
         public decimal FireAmount { get; set; }
 
@@ -130,6 +136,9 @@ namespace WoWsShipBuilder.Core.DataContainers
             decimal floodDps = hitPoints * shipHull.FloodingTickDamage / 100;
             decimal floodTotalDamage = floodDuration * floodDps;
 
+            decimal diveCapacityRechargeRateModifier = modifiers.FindModifiers("batteryRegenCoeff").Aggregate(1M, (current, modifier) => current * (decimal)modifier);
+            decimal diveCapacityModifier = modifiers.FindModifiers("batteryCapacityCoeff").Aggregate(1M, (current, modifier) => current * (decimal)modifier);
+
             var survivability = new SurvivabilityDataContainer
             {
                 HitPoints = (int)hitPoints,
@@ -143,6 +152,8 @@ namespace WoWsShipBuilder.Core.DataContainers
                 FloodTorpedoProtection = Math.Round(100 - modifiedFloodingCoeff, 1),
                 FloodDPS = Math.Round(floodDps),
                 FloodTotalDamage = Math.Round(floodTotalDamage),
+                DiveCapacity = Math.Round(shipHull.SubBatteryCapacity * diveCapacityModifier, 1),
+                DiveCapacityRechargeRate = Math.Round(shipHull.SubBatteryRegenRate * diveCapacityRechargeRateModifier, 1),
             };
 
             foreach (var location in shipHull.HitLocations)

--- a/WoWsShipBuilder.Core/Localization/Translation.Designer.cs
+++ b/WoWsShipBuilder.Core/Localization/Translation.Designer.cs
@@ -2142,6 +2142,15 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Battery.
+        /// </summary>
+        public static string ShipStats_Battery {
+            get {
+                return ResourceManager.GetString("ShipStats_Battery", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Blast.
         /// </summary>
         public static string ShipStats_Blast {
@@ -2213,6 +2222,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string ShipStats_Bow {
             get {
                 return ResourceManager.GetString("ShipStats_Bow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bow.
+        /// </summary>
+        public static string ShipStats_BowLoaders {
+            get {
+                return ResourceManager.GetString("ShipStats_BowLoaders", resourceCulture);
             }
         }
         
@@ -2496,6 +2514,24 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Capacity.
+        /// </summary>
+        public static string ShipStats_DiveCapacity {
+            get {
+                return ResourceManager.GetString("ShipStats_DiveCapacity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recharge rate.
+        /// </summary>
+        public static string ShipStats_DiveCapacityRechargeRate {
+            get {
+                return ResourceManager.GetString("ShipStats_DiveCapacityRechargeRate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Drop.
         /// </summary>
         public static string ShipStats_DropTime {
@@ -2627,6 +2663,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string ShipStats_FireTotalDamage {
             get {
                 return ResourceManager.GetString("ShipStats_FireTotalDamage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to First.
+        /// </summary>
+        public static string ShipStats_First {
+            get {
+                return ResourceManager.GetString("ShipStats_First", resourceCulture);
             }
         }
         
@@ -2937,6 +2982,15 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Loaders.
+        /// </summary>
+        public static string ShipStats_Loaders {
+            get {
+                return ResourceManager.GetString("ShipStats_Loaders", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Long range aura.
         /// </summary>
         public static string ShipStats_LongAura {
@@ -2978,6 +3032,24 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string ShipStats_ManeuverabilityRudderShiftTime {
             get {
                 return ResourceManager.GetString("ShipStats_ManeuverabilityRudderShiftTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Diving plane shift time.
+        /// </summary>
+        public static string ShipStats_ManeuverabilitySubsDivingPlaneShiftTime {
+            get {
+                return ResourceManager.GetString("ShipStats_ManeuverabilitySubsDivingPlaneShiftTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max dive speed.
+        /// </summary>
+        public static string ShipStats_ManeuverabilitySubsMaxDiveSpeed {
+            get {
+                return ResourceManager.GetString("ShipStats_ManeuverabilitySubsMaxDiveSpeed", resourceCulture);
             }
         }
         
@@ -3477,6 +3549,15 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Second.
+        /// </summary>
+        public static string ShipStats_Second {
+            get {
+                return ResourceManager.GetString("ShipStats_Second", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Secondary Battery.
         /// </summary>
         public static string ShipStats_SecondaryBattery {
@@ -3789,6 +3870,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string ShipStats_Stern {
             get {
                 return ResourceManager.GetString("ShipStats_Stern", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stern.
+        /// </summary>
+        public static string ShipStats_SternLoaders {
+            get {
+                return ResourceManager.GetString("ShipStats_SternLoaders", resourceCulture);
             }
         }
         
@@ -4455,6 +4545,24 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string Unit_ShotsPerMinute {
             get {
                 return ResourceManager.GetString("Unit_ShotsPerMinute", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unit.
+        /// </summary>
+        public static string Unit_U {
+            get {
+                return ResourceManager.GetString("Unit_U", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unit/s.
+        /// </summary>
+        public static string Unit_UPS {
+            get {
+                return ResourceManager.GetString("Unit_UPS", resourceCulture);
             }
         }
         

--- a/WoWsShipBuilder.Core/Localization/Translation.Designer.cs
+++ b/WoWsShipBuilder.Core/Localization/Translation.Designer.cs
@@ -1980,6 +1980,15 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Aircraft Carrier.
+        /// </summary>
+        public static string ShipStats_AirCarrier {
+            get {
+                return ResourceManager.GetString("ShipStats_AirCarrier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Aircrafts.
         /// </summary>
         public static string ShipStats_Aircraft {
@@ -2147,6 +2156,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string ShipStats_Battery {
             get {
                 return ResourceManager.GetString("ShipStats_Battery", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Battleship.
+        /// </summary>
+        public static string ShipStats_Battleship {
+            get {
+                return ResourceManager.GetString("ShipStats_Battleship", resourceCulture);
             }
         }
         
@@ -2388,11 +2406,29 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cruiser.
+        /// </summary>
+        public static string ShipStats_Cruiser {
+            get {
+                return ResourceManager.GetString("ShipStats_Cruiser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cruising.
         /// </summary>
         public static string ShipStats_CruisingSpeed {
             get {
                 return ResourceManager.GetString("ShipStats_CruisingSpeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cut-off Distances.
+        /// </summary>
+        public static string ShipStats_CutOffDistances {
+            get {
+                return ResourceManager.GetString("ShipStats_CutOffDistances", resourceCulture);
             }
         }
         
@@ -2447,6 +2483,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string ShipStats_DepthExplosion {
             get {
                 return ResourceManager.GetString("ShipStats_DepthExplosion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Destroyer.
+        /// </summary>
+        public static string ShipStats_Destroyer {
+            get {
+                return ResourceManager.GetString("ShipStats_Destroyer", resourceCulture);
             }
         }
         
@@ -2681,6 +2726,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string ShipStats_FirstOption {
             get {
                 return ResourceManager.GetString("ShipStats_FirstOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 1 ping.
+        /// </summary>
+        public static string ShipStats_FirstPing {
+            get {
+                return ResourceManager.GetString("ShipStats_FirstPing", resourceCulture);
             }
         }
         
@@ -3189,6 +3243,24 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Max turning speed.
+        /// </summary>
+        public static string ShipStats_MaxTurningSpeed {
+            get {
+                return ResourceManager.GetString("ShipStats_MaxTurningSpeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max vertical speed.
+        /// </summary>
+        public static string ShipStats_MaxVerticalSpeed {
+            get {
+                return ResourceManager.GetString("ShipStats_MaxVerticalSpeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Max view distance on ships.
         /// </summary>
         public static string ShipStats_MaxViewDistance {
@@ -3230,6 +3302,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string ShipStats_MinSpeed {
             get {
                 return ResourceManager.GetString("ShipStats_MinSpeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to More Details.
+        /// </summary>
+        public static string ShipStats_MoreDetails {
+            get {
+                return ResourceManager.GetString("ShipStats_MoreDetails", resourceCulture);
             }
         }
         
@@ -3549,6 +3630,24 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search angle.
+        /// </summary>
+        public static string ShipStats_SearchAngle {
+            get {
+                return ResourceManager.GetString("ShipStats_SearchAngle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search radius.
+        /// </summary>
+        public static string ShipStats_SearchRadius {
+            get {
+                return ResourceManager.GetString("ShipStats_SearchRadius", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Second.
         /// </summary>
         public static string ShipStats_Second {
@@ -3572,6 +3671,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string ShipStats_SecondOption {
             get {
                 return ResourceManager.GetString("ShipStats_SecondOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 2 pings.
+        /// </summary>
+        public static string ShipStats_SecondPing {
+            get {
+                return ResourceManager.GetString("ShipStats_SecondPing", resourceCulture);
             }
         }
         
@@ -3883,6 +3991,15 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Submarine.
+        /// </summary>
+        public static string ShipStats_Submarine {
+            get {
+                return ResourceManager.GetString("ShipStats_Submarine", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Superstructure section.
         /// </summary>
         public static string ShipStats_Superstructure {
@@ -4171,6 +4288,15 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Turning acceleration.
+        /// </summary>
+        public static string ShipStats_TurningAcceleration {
+            get {
+                return ResourceManager.GetString("ShipStats_TurningAcceleration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 180° turn time.
         /// </summary>
         public static string ShipStats_TurnTime {
@@ -4194,6 +4320,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string ShipStats_Type {
             get {
                 return ResourceManager.GetString("ShipStats_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Vertical acceleration.
+        /// </summary>
+        public static string ShipStats_VerticalAcceleration {
+            get {
+                return ResourceManager.GetString("ShipStats_VerticalAcceleration", resourceCulture);
             }
         }
         
@@ -4518,6 +4653,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string Unit_MPS {
             get {
                 return ResourceManager.GetString("Unit_MPS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to m/s².
+        /// </summary>
+        public static string Unit_MPS2 {
+            get {
+                return ResourceManager.GetString("Unit_MPS2", resourceCulture);
             }
         }
         

--- a/WoWsShipBuilder.Core/Localization/Translation.Designer.cs
+++ b/WoWsShipBuilder.Core/Localization/Translation.Designer.cs
@@ -3801,11 +3801,20 @@ namespace WoWsShipBuilder.Core.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show in Charts.
+        ///   Looks up a localized string similar to Show in Acceleration Charts.
         /// </summary>
-        public static string ShipStats_ShowInCharts {
+        public static string ShipStats_ShowInAccelerationCharts {
             get {
-                return ResourceManager.GetString("ShipStats_ShowInCharts", resourceCulture);
+                return ResourceManager.GetString("ShipStats_ShowInAccelerationCharts", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show in Ballistic Charts.
+        /// </summary>
+        public static string ShipStats_ShowInBallisticCharts {
+            get {
+                return ResourceManager.GetString("ShipStats_ShowInBallisticCharts", resourceCulture);
             }
         }
         
@@ -4572,6 +4581,15 @@ namespace WoWsShipBuilder.Core.Localization {
         public static string Unit_DegreePerSecond {
             get {
                 return ResourceManager.GetString("Unit_DegreePerSecond", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to °/s².
+        /// </summary>
+        public static string Unit_DegreePerSecond2 {
+            get {
+                return ResourceManager.GetString("Unit_DegreePerSecond2", resourceCulture);
             }
         }
         

--- a/WoWsShipBuilder.Core/Localization/Translation.resx
+++ b/WoWsShipBuilder.Core/Localization/Translation.resx
@@ -1706,4 +1706,52 @@ You can use the Change builds button to manage the builds of single ships. You c
   <data name="ShipStats_Battery" xml:space="preserve">
       <value>Battery</value>
   </data>
+  <data name="ShipStats_FirstPing" xml:space="preserve">
+      <value>1 ping</value>
+  </data>
+  <data name="ShipStats_SecondPing" xml:space="preserve">
+      <value>2 pings</value>
+  </data>
+  <data name="Unit_MPS2" xml:space="preserve">
+      <value>m/s²</value>
+  </data>
+  <data name="ShipStats_MaxTurningSpeed" xml:space="preserve">
+      <value>Max turning speed</value>
+  </data>
+  <data name="ShipStats_TurningAcceleration" xml:space="preserve">
+      <value>Turning acceleration</value>
+  </data>
+  <data name="ShipStats_MaxVerticalSpeed" xml:space="preserve">
+      <value>Max vertical speed</value>
+  </data>
+  <data name="ShipStats_VerticalAcceleration" xml:space="preserve">
+      <value>Vertical acceleration</value>
+  </data>
+  <data name="ShipStats_SearchRadius" xml:space="preserve">
+      <value>Search radius</value>
+  </data>
+  <data name="ShipStats_SearchAngle" xml:space="preserve">
+      <value>Search angle</value>
+  </data>
+  <data name="ShipStats_AirCarrier" xml:space="preserve">
+      <value>Aircraft Carrier</value>
+  </data>
+  <data name="ShipStats_Submarine" xml:space="preserve">
+      <value>Submarine</value>
+  </data>
+  <data name="ShipStats_Cruiser" xml:space="preserve">
+      <value>Cruiser</value>
+  </data>
+  <data name="ShipStats_Battleship" xml:space="preserve">
+      <value>Battleship</value>
+  </data>
+  <data name="ShipStats_Destroyer" xml:space="preserve">
+      <value>Destroyer</value>
+  </data>
+  <data name="ShipStats_MoreDetails" xml:space="preserve">
+      <value>More Details</value>
+  </data>
+  <data name="ShipStats_CutOffDistances" xml:space="preserve">
+      <value>Cut-off Distances</value>
+  </data>
 </root>

--- a/WoWsShipBuilder.Core/Localization/Translation.resx
+++ b/WoWsShipBuilder.Core/Localization/Translation.resx
@@ -1670,4 +1670,40 @@ You can use the Change builds button to manage the builds of single ships. You c
   <data name="Validation_ShipInBuild" xml:space="preserve">
       <value>Ship in the build</value>
   </data>
+  <data name="ShipStats_Loaders" xml:space="preserve">
+      <value>Loaders</value>
+  </data>
+  <data name="ShipStats_BowLoaders" xml:space="preserve">
+      <value>Bow</value>
+  </data>
+  <data name="ShipStats_SternLoaders" xml:space="preserve">
+      <value>Stern</value>
+  </data>
+  <data name="ShipStats_First" xml:space="preserve">
+      <value>First</value>
+  </data>
+  <data name="ShipStats_Second" xml:space="preserve">
+      <value>Second</value>
+  </data>
+  <data name="Unit_U" xml:space="preserve">
+      <value>unit</value>
+  </data>
+  <data name="Unit_UPS" xml:space="preserve">
+      <value>unit/s</value>
+  </data>
+  <data name="ShipStats_ManeuverabilitySubsMaxDiveSpeed" xml:space="preserve">
+      <value>Max dive speed</value>
+  </data>
+  <data name="ShipStats_ManeuverabilitySubsDivingPlaneShiftTime" xml:space="preserve">
+      <value>Diving plane shift time</value>
+  </data>
+  <data name="ShipStats_DiveCapacity" xml:space="preserve">
+      <value>Capacity</value>
+  </data>
+  <data name="ShipStats_DiveCapacityRechargeRate" xml:space="preserve">
+      <value>Recharge rate</value>
+  </data>
+  <data name="ShipStats_Battery" xml:space="preserve">
+      <value>Battery</value>
+  </data>
 </root>

--- a/WoWsShipBuilder.Core/Localization/Translation.resx
+++ b/WoWsShipBuilder.Core/Localization/Translation.resx
@@ -1655,8 +1655,11 @@ You can use the Change builds button to manage the builds of single ships. You c
   <data name="WebApp_GoToShipsPage" xml:space="preserve">
       <value>Go to ships page</value>
   </data>
-  <data name="ShipStats_ShowInCharts" xml:space="preserve">
-      <value>Show in Charts</value>
+  <data name="ShipStats_ShowInBallisticCharts" xml:space="preserve">
+      <value>Show in Ballistic Charts</value>
+  </data>
+  <data name="ShipStats_ShowInAccelerationCharts" xml:space="preserve">
+      <value>Show in Acceleration Charts</value>
   </data>
   <data name="Validation_InvalidBuild" xml:space="preserve">
       <value>Invalid build</value>
@@ -1753,5 +1756,8 @@ You can use the Change builds button to manage the builds of single ships. You c
   </data>
   <data name="ShipStats_CutOffDistances" xml:space="preserve">
       <value>Cut-off Distances</value>
+  </data>
+  <data name="Unit_DegreePerSecond2" xml:space="preserve">
+      <value>°/s²</value>
   </data>
 </root>

--- a/WoWsShipBuilder.Core/WoWsShipBuilder.Core.csproj
+++ b/WoWsShipBuilder.Core/WoWsShipBuilder.Core.csproj
@@ -18,7 +18,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="System.IO.Abstractions" Version="19.1.18" />
-      <PackageReference Include="WoWsShipBuilder.DataStructures" Version="3.1.2" />
+      <PackageReference Include="WoWsShipBuilder.DataStructures" Version="3.1.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/WoWsShipBuilder.Core/WoWsShipBuilder.Core.csproj
+++ b/WoWsShipBuilder.Core/WoWsShipBuilder.Core.csproj
@@ -18,7 +18,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="System.IO.Abstractions" Version="19.1.18" />
-      <PackageReference Include="WoWsShipBuilder.DataStructures" Version="3.1.0" />
+      <PackageReference Include="WoWsShipBuilder.DataStructures" Version="3.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/WoWsShipBuilder.Core/WoWsShipBuilder.Core.csproj
+++ b/WoWsShipBuilder.Core/WoWsShipBuilder.Core.csproj
@@ -18,7 +18,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="System.IO.Abstractions" Version="19.1.18" />
-      <PackageReference Include="WoWsShipBuilder.DataStructures" Version="3.1.1" />
+      <PackageReference Include="WoWsShipBuilder.DataStructures" Version="3.1.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/WoWsShipBuilder.Web/Components/CaptainSkillSelector.razor
+++ b/WoWsShipBuilder.Web/Components/CaptainSkillSelector.razor
@@ -70,24 +70,24 @@
                                             <MudText Align="Align.Left" Typo="Typo.body2" Style="white-space: break-spaces">@localization</MudText>
                                         }
                                     }
-                                    @if (skill.Modifiers is {Count: > 0 })
+                                    @if (skill.Modifiers is { Count: > 0 })
                                     {
                                         <MudDivider Light="true" Class="ma-1"/>
                                         foreach ((string modifierName, float modifierValue) in skill.Modifiers)
                                         {
                                             // this is here so we can have the call to the ModifierProcessor only once, to share the value between the if and the mudtext
                                             string modifierString = ModifierProcessor.GetUiModifierString(modifierName, modifierValue, ReturnFilter.All, Localizer);
-                                            @if (!string.IsNullOrWhiteSpace(modifierString))
+                                            if (!string.IsNullOrWhiteSpace(modifierString))
                                             {
                                                 <MudText Align="Align.Left" Typo="Typo.body2">@modifierString</MudText>
                                             }
                                         }
                                     }
-                                    @if (skill.ConditionalModifiers is {Count: > 0 })
+                                    @if (skill.ConditionalModifiers is { Count: > 0 })
                                     {
                                         <MudDivider Light="true" Class="ma-1"/>
                                         <MudText Align="Align.Left" Typo="Typo.body2" GutterBottom>
-                                            @Localizer.GetGameLocalization("SKILL_TRIGGER_" + skill.Skill.ConditionalTriggerType).Localization
+                                            @Localizer.GetGameLocalization(!string.IsNullOrWhiteSpace(skill.Skill.ConditionalTriggerDescription) ? skill.Skill.ConditionalTriggerDescription : "SKILL_TRIGGER_" + skill.Skill.ConditionalTriggerType).Localization
                                         </MudText>
                                         foreach ((string modifierName, float modifierValue) in skill.ConditionalModifiers)
                                         {

--- a/WoWsShipBuilder.Web/Components/CaptainSkillSelector.razor
+++ b/WoWsShipBuilder.Web/Components/CaptainSkillSelector.razor
@@ -232,7 +232,7 @@
             ["ViewModel"] = ViewModel,
         };
 
-        var dialog = DialogService.Show<CaptainTalentsAndConditionalSkillDialog>("CaptainTalentsAndConditionalSkillDialog", parameters, options);
+        var dialog = await DialogService.ShowAsync<CaptainTalentsAndConditionalSkillDialog>("CaptainTalentsAndConditionalSkillDialog", parameters, options);
         // this is needed to wait for the dialog to close to change the SkillActivationPopupOpen, to get the values to update
         await dialog.Result;
         ViewModel!.SkillActivationPopupOpen = false;

--- a/WoWsShipBuilder.Web/Components/ConsumableSelector.razor
+++ b/WoWsShipBuilder.Web/Components/ConsumableSelector.razor
@@ -20,7 +20,7 @@
                             <ActivatorContent>
                                 <MudTooltip Color="Color.Transparent" Placement="Placement.Right" Delay="400">
                                     <ChildContent>
-                                        <MudButton @onmouseup="@(args => ActivateConsumable(args, consumableSlot))" @oncontextmenu:preventDefault="true" Style="@(GetImageBreakpointStyle() + GetColorFromStatus(consumableSlot, true))" Variant="Variant.Outlined">
+                                        <MudButton @onmousedown="@(args => ActivateConsumable(args, consumableSlot))" @oncontextmenu:preventDefault="true" Style="@(GetImageBreakpointStyle() + GetColorFromStatus(consumableSlot, true))" Variant="Variant.Outlined">
                                             <MudImage Width="@GetImageSize()" Height="@GetImageSize()" Src="@GetConsumableIcon(consumableSlot.SelectedConsumable)" @ontouchend="StopTimer" @ontouchstart="@(_ => StartTimer(consumableSlot))" draggable="false" Style="-webkit-touch-callout: none; -webkit-user-select: none;"/>
                                         </MudButton>
                                     </ChildContent>
@@ -50,7 +50,7 @@
                     }
                     else
                     {
-                        <MudTooltip Color="Color.Transparent" Placement="Placement.Right" RootStyle="@(GetImageBreakpointStyle() + GetColorFromStatus(consumableSlot, false))" @onmouseup="@(args => ActivateConsumable(args, consumableSlot))" @oncontextmenu:preventDefault="true" Delay="400">
+                        <MudTooltip Color="Color.Transparent" Placement="Placement.Right" RootStyle="@(GetImageBreakpointStyle() + GetColorFromStatus(consumableSlot, false))" @onmousedown="@(args => ActivateConsumable(args, consumableSlot))" @oncontextmenu:preventDefault="true" Delay="400">
                             <ChildContent>
                                 <MudImage Width="@GetImageSize()" Height="@GetImageSize()" Src="@GetConsumableIcon(consumableSlot.SelectedConsumable)" @ontouchend="StopTimer" @ontouchstart="@(_ => StartTimer(consumableSlot))" draggable="false" Style="-webkit-touch-callout: none; -webkit-user-select: none;"/>
                             </ChildContent>

--- a/WoWsShipBuilder.Web/Components/ConsumableSelector.razor
+++ b/WoWsShipBuilder.Web/Components/ConsumableSelector.razor
@@ -80,8 +80,12 @@
     {
         <MudPaper Outlined="true" Style="min-width: 300px; max-width: 300px">
             <MudStack Spacing="0" Class="pa-2">
-                <MudText Align="Align.Center" Typo="Typo.h6">@pair.localizer.GetGameLocalization("DOCK_CONSUME_TITLE_" + pair.consumableData.Name).Localization</MudText>
-                <MudText Align="Align.Center" Typo="Typo.body2" Style="white-space: break-spaces">@pair.localizer.GetGameLocalization("DOCK_CONSUME_DESCRIPTION_" + pair.consumableData.Name).Localization</MudText>
+                <MudText Align="Align.Center" Typo="Typo.h6">
+                    @pair.localizer.GetGameLocalization("DOCK_CONSUME_TITLE_" + pair.consumableData.Name).Localization
+                </MudText>
+                <MudText Align="Align.Center" Typo="Typo.body2" Style="white-space: break-spaces">
+                    @pair.localizer.GetGameLocalization("DOCK_CONSUME_DESCRIPTION_" + pair.consumableData.Name).Localization
+                </MudText>
                 <MudDivider Light="true" Class="ma-1"/>
                 @foreach (var data in pair.consumableData.DataElements)
                 {
@@ -96,8 +100,12 @@
                     if (!string.IsNullOrWhiteSpace(modifierDesc) && !string.IsNullOrWhiteSpace(modifierValueString))
                     {
                         <div class="d-flex justify-space-between">
-                            <MudText Typo="Typo.body2" Class="flex-grow-0 flex-shrink-1">@modifierDesc</MudText>
-                            <MudText Typo="Typo.body2" Align="Align.End" Class="flex-grow-1 flex-shrink-0 pl-2 align-self-center">@modifierValueString</MudText>
+                            <MudText Typo="Typo.body2" Class="flex-grow-0 flex-shrink-1">
+                                @modifierDesc
+                            </MudText>
+                            <MudText Typo="Typo.body2" Align="Align.End" Class="flex-grow-1 flex-shrink-0 pl-2 align-self-center">
+                                @modifierValueString
+                            </MudText>
                         </div>
                     }
                 }

--- a/WoWsShipBuilder.Web/Components/ConsumableSelector.razor
+++ b/WoWsShipBuilder.Web/Components/ConsumableSelector.razor
@@ -93,7 +93,7 @@
                     // this is here so we can have the call to the ModifierProcessor only once, to share the value between the if and the mudtext
                     string modifierDesc = ModifierProcessor.GetUiModifierString(modifierName, modifierValue, ReturnFilter.Description, pair.localizer);
                     string modifierValueString = ModifierProcessor.GetUiModifierString(modifierName, modifierValue, ReturnFilter.Value, pair.localizer);
-                    @if (!string.IsNullOrWhiteSpace(modifierDesc) && !string.IsNullOrWhiteSpace(modifierValueString))
+                    if (!string.IsNullOrWhiteSpace(modifierDesc) && !string.IsNullOrWhiteSpace(modifierValueString))
                     {
                         <div class="d-flex justify-space-between">
                             <MudText Typo="Typo.body2" Class="flex-grow-0 flex-shrink-1">@modifierDesc</MudText>

--- a/WoWsShipBuilder.Web/Components/DispersionPlot.razor
+++ b/WoWsShipBuilder.Web/Components/DispersionPlot.razor
@@ -40,7 +40,7 @@
 @code {
 
     [Parameter]
-    public Dictionary<Guid, DispersionEllipse> Ships { get; set; } = default!;
+    public Dictionary<Guid, DispersionEllipse> Ships { get; set; } = new();
     [Parameter]
     public double PlotScaling { get; set; }
     [Parameter, EditorRequired]

--- a/WoWsShipBuilder.Web/Components/DispersionPlot.razor
+++ b/WoWsShipBuilder.Web/Components/DispersionPlot.razor
@@ -40,7 +40,7 @@
 @code {
 
     [Parameter]
-    public Dictionary<Guid, DispersionEllipse> Ships { get; set; } = new();
+    public Dictionary<Guid, DispersionEllipse> Ships { get; set; } = new(); //cant use ImmutableDictionary because it causes the loss of the items oder which is very important in this case
     [Parameter]
     public double PlotScaling { get; set; }
     [Parameter, EditorRequired]

--- a/WoWsShipBuilder.Web/Components/DispersionPlot.razor
+++ b/WoWsShipBuilder.Web/Components/DispersionPlot.razor
@@ -39,9 +39,9 @@
 
 @code {
 
-    [Parameter, EditorRequired]
-    public ImmutableDictionary<Guid, DispersionEllipse> Ships { get; set; } = default!;
-    [Parameter, EditorRequired]
+    [Parameter]
+    public Dictionary<Guid, DispersionEllipse> Ships { get; set; } = default!;
+    [Parameter]
     public double PlotScaling { get; set; }
     [Parameter, EditorRequired]
     public ChartsHelper.EllipsePlanes EllipsePlane { get; set; }

--- a/WoWsShipBuilder.Web/Components/SharedFragments.razor
+++ b/WoWsShipBuilder.Web/Components/SharedFragments.razor
@@ -38,7 +38,7 @@
                         <div class="d-flex justify-space-between">
                             <MudText Class="flex-grow-0 flex-shrink-1" Typo="Typo.body2">
                                     @group.localizer.GetAppLocalization(element.Key).Localization
-                                    <MudIcon ViewBox="0 -14 36 36" Icon="@Icons.Outlined.Info" Size="Size.Small" Class="mt-n2"/>
+                                    <MudIcon ViewBox="0 -14 36 36" Icon="@Icons.Material.Outlined.Info" Size="Size.Small" Class="mt-n2"/>
                                 </MudText>
                             <MudText Typo="Typo.body2" Align="Align.End" Class="flex-grow-1 flex-shrink-0 pl-2 align-self-center">@(element.Value + " " + group.localizer.GetAppLocalization(element.Unit).Localization)</MudText>
                         </div>

--- a/WoWsShipBuilder.Web/Components/ShipModulesSelector.razor
+++ b/WoWsShipBuilder.Web/Components/ShipModulesSelector.razor
@@ -17,7 +17,7 @@
                         <MudStack AlignItems="AlignItems.Center">
                             @if (columnUpgrade.IndexOf(upgrade) != 0)
                             {
-                                <MudIcon Icon="@Icons.Filled.ArrowDropDown"/>
+                                <MudIcon Icon="@Icons.Material.Filled.ArrowDropDown"/>
                             }
                             <MudButton OnClick="@(_ => ViewModel.SelectModuleExecute(upgrade))" Class="pa-2" Style="@GetImageStyle()" Variant="Variant.Outlined" >
                                 <MudImage Width="@GetImageSize()" Height="@GetImageSize()" Src="@GetModuleIcon(upgrade, ViewModel.SelectedModules.Contains(upgrade))"/>

--- a/WoWsShipBuilder.Web/Components/ShipSelector.razor
+++ b/WoWsShipBuilder.Web/Components/ShipSelector.razor
@@ -72,7 +72,7 @@
     @if (!LargerList)
     {
         <MudItem xs="12" md="4">
-            <MudButton StartIcon="@Icons.Outlined.Cancel" Color="Color.Primary" DisableElevation="true" FullWidth Style="height: 14.6%; outline: inherit" Class="mt-4 mb-2" Variant="Variant.Filled" OnClick="RemoveAllShips" >Clear all</MudButton>
+            <MudButton StartIcon="@Icons.Material.Outlined.Cancel" Color="Color.Primary" DisableElevation="true" FullWidth Style="height: 14.6%; outline: inherit" Class="mt-4 mb-2" Variant="Variant.Filled" OnClick="RemoveAllShips" >Clear all</MudButton>
             <MudPaper Outlined="true" Style="height: 300px; max-height: 300px; overflow: auto">
                 <MudList Style="max-height: 300px;" Dense>
                     @if (!SelectedShips.Any())
@@ -93,13 +93,13 @@
                                         <MudText>
                                             @Localizer.GetGameLocalization(shipContainer.ShipIndex + "_FULL").Localization
                                         </MudText>
-                                        <MudIcon Icon="@Icons.Filled.Close" @onclick="@(_ => RemoveShip(shipContainer))" Style="cursor: pointer"/>
+                                        <MudIcon Icon="@Icons.Material.Filled.Close" @onclick="@(_ => RemoveShip(shipContainer))" Style="cursor: pointer"/>
                                     </MudStack>
                                     <MudStack Row AlignItems="AlignItems.Baseline">
                                         <MudText Style="text-overflow: ellipsis; overflow: hidden" Typo="Typo.body2" Class="ml-2 mt-n1" @onclick="@(_ => AddBuildString(shipContainer))">
                                             @(Localizer.GetAppLocalization(Translation.ChartsWeb_Build).Localization + ": " + (!string.IsNullOrWhiteSpace(GetBuildName(shipContainer.BuildString)) ? GetBuildName(shipContainer.BuildString) : ShipComparisonViewModel.DefaultBuildName))
                                         </MudText>
-                                        <MudIcon Size="Size.Small" Icon="@Icons.Filled.Edit" @onclick="@(_ => AddBuildString(shipContainer))" Style="cursor: pointer; alignment-baseline: hanging; font-size: small" ViewBox="0 -3 24 24"/>
+                                        <MudIcon Size="Size.Small" Icon="@Icons.Material.Filled.Edit" @onclick="@(_ => AddBuildString(shipContainer))" Style="cursor: pointer; alignment-baseline: hanging; font-size: small" ViewBox="0 -3 24 24"/>
                                     </MudStack>
                                 </MudStack>
                                 <MudDivider Class="mt-1"/>
@@ -304,7 +304,7 @@
         };
         var dialog = DialogService.Show<BuildStringInputDialog>(Localizer.SimpleAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink)), parameters);
         var result = await dialog.Result;
-        if (!result.Cancelled && result.Data is string buildStr)
+        if (!result.Canceled && result.Data is string buildStr)
         {
             SelectedShips.Replace(SelectedShips.Single(x => x.Id.Equals(ship.Id)), ship with { BuildString = buildStr });
         }

--- a/WoWsShipBuilder.Web/Components/ShipSelector.razor
+++ b/WoWsShipBuilder.Web/Components/ShipSelector.razor
@@ -302,7 +302,7 @@
         {
             ["SelectedShipIndex"] = ship.ShipIndex,
         };
-        var dialog = DialogService.Show<BuildStringInputDialog>(Localizer.SimpleAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink)), parameters);
+        var dialog = await DialogService.ShowAsync<BuildStringInputDialog>(Localizer.SimpleAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink)), parameters);
         var result = await dialog.Result;
         if (!result.Canceled && result.Data is string buildStr)
         {

--- a/WoWsShipBuilder.Web/Components/ShipStatsComponent.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsComponent.razor
@@ -416,7 +416,7 @@
                     <MudStack Spacing="1" Class="expander-content-padding mb-n3">
                          @DataElementFragment((ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements[0]!, Localizer))
                          @{
-                            var j = ViewModel.CurrentShipStats.PingerGunDataContainer is null ? 2 : 3; // subs have battery data that other ships do not have so we have to account for it
+                            var j = ViewModel.CurrentShipStats?.PingerGunDataContainer is null ? 2 : 3; // subs have battery data that other ships do not have so we have to account for it
                             for(int i = ViewModel.CurrentShipStats!.SurvivabilityDataContainer.DataElements.Count - j; i < ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements.Count; i++)
                             {
                                 @DataElementFragment((ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements[i]!, Localizer))

--- a/WoWsShipBuilder.Web/Components/ShipStatsComponent.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsComponent.razor
@@ -415,13 +415,16 @@
                 <ChildContent>
                     <MudStack Spacing="1" Class="expander-content-padding mb-n3">
                          @DataElementFragment((ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements[0]!, Localizer))
-                         @for (int i = ViewModel.CurrentShipStats!.SurvivabilityDataContainer.DataElements.Count - 2; i < ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements.Count; i++)
-                         {
-                             @DataElementFragment((ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements[i]!, Localizer))
+                         @{
+                            var j = ViewModel.CurrentShipStats.PingerGunDataContainer is null ? 2 : 3; // subs have battery data that other ships do not have so we have to account for it
+                            for(int i = ViewModel.CurrentShipStats!.SurvivabilityDataContainer.DataElements.Count - j; i < ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements.Count; i++)
+                            {
+                                @DataElementFragment((ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements[i]!, Localizer))
+                            }
                          }
                         <MudExpansionPanel DisableGutters Text="@Localizer.GetAppLocalization(nameof(Translation.ShipStats_ShipSectionsHp)).Localization" Style="border-bottom: initial" Class="child-expander rounded-0 mt-1">
                             <MudStack Spacing="1" Class="expander-content-padding mb-n3">
-                                @for (var i = 1; i < ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements.Count - 2; i++)
+                                @for (var i = 1; i < ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements.Count - j; i++)
                                 {
                                     @DataElementFragment((ViewModel.CurrentShipStats?.SurvivabilityDataContainer.DataElements[i]!, Localizer))
                                 }

--- a/WoWsShipBuilder.Web/Components/ShipStatsComponent.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsComponent.razor
@@ -13,6 +13,7 @@
 @using WoWsShipBuilder.Web.Dialogs
 @using WoWsShipBuilder.Web.Services
 @using System.ComponentModel.DataAnnotations
+@using WoWsShipBuilder.Core.Extensions
 @inherits ReactiveComponentBase<ShipStatsControlViewModel>
 @inject ILocalizer Localizer
 @inject NavigationManager NavManager
@@ -139,14 +140,26 @@
                                 <!--Border bottom initial needed to fix the first expander having a wrong color when closed-->
                                 <MudExpansionPanel DisableGutters Text="@Localizer.GetGameLocalization(torpedo.Name).Localization" IsInitiallyExpanded="@(AppSettings.WebAppSettings?.OpenAllAmmoExpandersByDefault ?? true)" Style="border-bottom: initial" Class="child-expander rounded-0">
                                     <MudStack Spacing="1" Class="expander-content-padding mb-n3">
-                                        @foreach (var data in torpedo.DataElements)
+                                        @if (torpedo.TorpedoType.Equals($"ShipStats_Torpedo{TorpedoType.Magnetic.TorpedoTypeToString()}"))
                                         {
-                                            @DataElementFragment((data, Localizer))
+                                            for(int i = 0; i < torpedo.DataElements.Count - 11; i++)
+                                            {
+                                                @DataElementFragment((torpedo.DataElements[i]!, Localizer))
+                                            }   
+                                        }
+                                        else
+                                        {
+                                            foreach (var data in torpedo.DataElements)
+                                            {
+                                                @DataElementFragment((data, Localizer))
+                                            }
                                         }
                                         @if (torpedo.CanHitClasses is not null)
                                         {
                                             <div class="d-flex justify-space-between">
-                                                <MudText Typo="Typo.body2" Class="flex-grow-0 flex-shrink-1">@Localizer.GetAppLocalization(nameof(Translation.ShipStats_CanHitClasses)).Localization</MudText>
+                                                <MudText Typo="Typo.body2" Class="flex-grow-0 flex-shrink-1">
+                                                    @Localizer.GetAppLocalization(nameof(Translation.ShipStats_CanHitClasses)).Localization
+                                                </MudText>
                                                 <MudStack Row="true">
                                                     @foreach (var shipClass in torpedo.CanHitClasses)
                                                     {
@@ -154,6 +167,25 @@
                                                     }
                                                 </MudStack>
                                             </div>
+                                        }
+                                        @if (torpedo.TorpedoType.Equals($"ShipStats_Torpedo{TorpedoType.Magnetic.TorpedoTypeToString()}"))
+                                        {
+                                            <MudExpansionPanel DisableGutters Text="@Localizer.GetAppLocalization(nameof(Translation.ShipStats_MoreDetails)).Localization" Style="border-bottom: initial" Class="child-expander rounded-0 mt-1">
+                                                <MudStack Spacing="1" Class="expander-content-padding mb-n3">
+                                                    @for (var i = torpedo.DataElements.Count - 11; i < torpedo.DataElements.Count - 5; i++)
+                                                    {
+                                                        @DataElementFragment((torpedo.DataElements[i]!, Localizer))
+                                                    }
+                                                </MudStack>
+                                            </MudExpansionPanel>
+                                            <MudExpansionPanel DisableGutters Text="@Localizer.GetAppLocalization(nameof(Translation.ShipStats_CutOffDistances)).Localization" Style="border-bottom: initial" Class="child-expander rounded-0 mt-1">
+                                                <MudStack Spacing="1" Class="expander-content-padding mb-n3">
+                                                    @for (var i = torpedo.DataElements.Count - 5; i < torpedo.DataElements.Count; i++)
+                                                    {
+                                                        @DataElementFragment((torpedo.DataElements[i]!, Localizer))
+                                                    }
+                                                </MudStack>
+                                            </MudExpansionPanel>   
                                         }
                                     </MudStack>
                                 </MudExpansionPanel>
@@ -432,7 +464,6 @@
                         </MudExpansionPanel>
                     </MudStack>
                 </ChildContent>
-
             </MudExpansionPanel>
 
             <!--T11 abilities-->

--- a/WoWsShipBuilder.Web/Components/ShipStatsComponent.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsComponent.razor
@@ -45,7 +45,7 @@
                                     <MudText Typo="Typo.body2" Class="flex-grow-0 flex-shrink-1">
                                         @Localizer.GetAppLocalization(nameof(Translation.ShipStats_HorizontalDisp)).Localization
                                     </MudText>
-                                    <MudIcon ViewBox="-5 -1 36 36" Icon="@Icons.Outlined.Info" Size="Size.Small"/>
+                                    <MudIcon ViewBox="-5 -1 36 36" Icon="@Icons.Material.Outlined.Info" Size="Size.Small"/>
                                     <MudText Typo="Typo.body2" Align="Align.End" Class="flex-grow-1 flex-shrink-0 pl-2 align-self-center">
                                         @(ViewModel.CurrentShipStats.MainBatteryDataContainer.HorizontalDisp + " " + Localizer.GetAppLocalization(nameof(Translation.Unit_M)).Localization)
                                     </MudText>
@@ -66,7 +66,7 @@
                             <ChildContent>
                                 <div class="ml-3 d-flex justify-space-between">
                                     <MudText Typo="Typo.body2" Class="flex-grow-0 flex-shrink-1">@Localizer.GetAppLocalization(nameof(Translation.ShipStats_VerticalDisp)).Localization</MudText>
-                                    <MudIcon ViewBox="-5 -1 36 36" Icon="@Icons.Outlined.Info" Size="Size.Small"/>
+                                    <MudIcon ViewBox="-5 -1 36 36" Icon="@Icons.Material.Outlined.Info" Size="Size.Small"/>
                                     <MudText Typo="Typo.body2" Align="Align.End" Class="flex-grow-1 flex-shrink-0 pl-2 align-self-center">@(ViewModel.CurrentShipStats.MainBatteryDataContainer.VerticalDisp + " " + Localizer.GetAppLocalization(nameof(Translation.Unit_M)).Localization)</MudText>
                                 </div>
                             </ChildContent>

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -224,12 +224,7 @@
                 buildName = build.BuildName;
             }
 
-            var shipSummary = AppData.ShipSummaryList.Single(x => x.Index.Equals(shipIndex));
-            var ship = AppData.FindShipFromSummary(shipSummary);
-            var vmParams = new ShipViewModelParams(ship, shipSummary, build);
-
-            ShipViewModel vm = new(null!, Localizer, vmParams);
-            await vm.InitializeData(vmParams);
+            var vm = await CreateViewModel(shipIndex, build, Localizer);
             shipChanged = true;
             return vm;
         }
@@ -343,10 +338,16 @@
         return container;
     }
 
-    public async Task<ShipViewModel?> GetShipViewModel(string shipIndex, string? buildString)
+    public static async Task<ShipViewModel> CreateViewModel(string shipIndex, Build? build, ILocalizer localizer)
     {
-        BuildString = buildString;
-        return await LoadShipViewModel(shipIndex);
+        var shipSummary = AppData.ShipSummaryList.Single(x => x.Index.Equals(shipIndex));
+        var ship = AppData.FindShipFromSummary(shipSummary);
+        var vmParams = new ShipViewModelParams(ship, shipSummary, build);
+
+        ShipViewModel vm = new(null!, localizer, vmParams);
+        await vm.InitializeData(vmParams);
+        
+        return vm;
     }
 
     public string GetBuildName()

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -284,7 +284,7 @@
             ["ShortLinkDisabled"] = !LinkShortener.IsAvailable,
             ["BuildName"] = buildName,
         };
-        var dialog = DialogService.Show<BuildShareDialog>(string.Empty, parameters, options);
+        var dialog = await DialogService.ShowAsync<BuildShareDialog>(string.Empty, parameters, options);
         var result = await dialog.Result;
         if (!result.Canceled && result.Data is BuildShareResult shareResult)
         {

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -30,6 +30,25 @@
 
 @inherits ReactiveComponentBase<ShipViewModel>
 
+@if (!(initialized && SettingsInitialized))
+{
+    <MudGrid>
+        <MudItem xs="12">
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="166px"/>
+        </MudItem>
+        <MudItem xs="12" md="6" lg="4" xl="3">
+            <MudStack>
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="250px"/>
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="100px"/>
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="450px"/>
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="450px"/>
+            </MudStack>
+        </MudItem>
+        <MudItem xs="12" md="6" lg="8" xl="9">
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="100%"/>
+        </MudItem>
+    </MudGrid>
+}
 @if (ViewModel is not null)
 {
     <MudGrid>

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -10,6 +10,7 @@
 @using WoWsShipBuilder.Web.Dialogs
 @using System.Net
 @using System.Diagnostics
+@using Microsoft.Extensions.Caching.Memory
 @using WoWsShipBuilder.Core.Builds
 @using WoWsShipBuilder.Core.DataContainers
 @using WoWsShipBuilder.Core.Extensions
@@ -56,7 +57,7 @@
             <MudPaper Outlined="true" Class="py-2 px-15">
                 <MudGrid Justify="Justify.Center">
                     <MudItem xs="12" md="2" Class="align-self-center d-flex justify-center">
-                        <MudTextField @bind-Value="buildName" Label="Build:" Immediate Placeholder="Enter build name" Variant="Variant.Outlined" Margin="Margin.Dense"/>
+                        <MudTextField @bind-Value="BuildName" Label="Build:" Immediate Placeholder="Enter build name" Variant="Variant.Outlined" Margin="Margin.Dense"/>
                     </MudItem>
                     <MudItem xs="12" md="8" Class="@(GetShipAlign() + " d-flex justify-center")">
                         @if (ViewModel.PreviousShip is not null)
@@ -98,38 +99,21 @@
                 </MudGrid>
             </MudPaper>
         </MudItem>
-        @if (!(initialized && SettingsInitialized))
-        {
-            <MudItem xs="12" md="6" lg="4" xl="3">
-                <MudStack>
-                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="250px"/>
-                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="100px"/>
-                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="450px"/>
-                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="450px"/>
-                </MudStack>
-            </MudItem>
-            <MudItem xs="12" md="6" lg="8" xl="9">
-                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="100%"/>
-            </MudItem>
-        }
-        else
-        {
-            <MudItem xs="12" md="6" lg="4" xl="3">
-                <MudStack>
-                    <ShipModulesSelector ViewModel="@ViewModel.ShipModuleViewModel"/>
-                    <ShipUpgradeSelector ViewModel="@ViewModel.UpgradePanelViewModel"/>
-                    <ConsumableSelector ViewModel="@ViewModel.ConsumableViewModel"/>
-                    <CaptainSkillSelector ViewModel="@ViewModel.CaptainSkillSelectorViewModel" ShipClass="@ViewModel.CurrentShip.ShipClass"/>
-                    <SignalSelector ViewModel="@ViewModel.SignalSelectorViewModel"/>
-                </MudStack>
-            </MudItem>
-            <MudItem xs="12" md="6" lg="8" xl="9">
-                @if (ViewModel?.ShipStatsControlViewModel?.CurrentShipStats is not null)
-                {
-                    <ShipStatsComponent ViewModel="@ViewModel.ShipStatsControlViewModel" SaveBuildStringIntoLocal="@(_ => SaveBuildStringToLocalStorage())"/>
-                }
-            </MudItem>
-        }
+        <MudItem xs="12" md="6" lg="4" xl="3">
+            <MudStack>
+                <ShipModulesSelector ViewModel="@ViewModel.ShipModuleViewModel"/>
+                <ShipUpgradeSelector ViewModel="@ViewModel.UpgradePanelViewModel"/>
+                <ConsumableSelector ViewModel="@ViewModel.ConsumableViewModel"/>
+                <CaptainSkillSelector ViewModel="@ViewModel.CaptainSkillSelectorViewModel" ShipClass="@ViewModel.CurrentShip.ShipClass"/>
+                <SignalSelector ViewModel="@ViewModel.SignalSelectorViewModel"/>
+            </MudStack>
+        </MudItem>
+        <MudItem xs="12" md="6" lg="8" xl="9">
+            @if (ViewModel?.ShipStatsControlViewModel?.CurrentShipStats is not null)
+            {
+                <ShipStatsComponent ViewModel="@ViewModel.ShipStatsControlViewModel" SaveBuildStringIntoLocal="@(_ => SaveBuildStringToLocalStorage())"/>
+            }
+        </MudItem>
     </MudGrid>
 }
 
@@ -149,8 +133,8 @@
     [Parameter]
     public string? BuildString { get; set; }
 
-    [Parameter]
-    public ShipStatsContainer? CachedInstance { get; set; }
+    [Parameter, EditorRequired]
+    public VmCacheService CacheService { get; set; } = default!;
 
     [CascadingParameter]
     private Breakpoint Breakpoint { get; set; }
@@ -164,23 +148,28 @@
 
     private bool shipChanged;
 
-    private string buildName = string.Empty;
+    private string BuildName
+    {
+        get => CacheService[CurrentTabId]?.BuildName ?? string.Empty;
+        set => CacheService[CurrentTabId]!.BuildName = value;
+    }
 
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
         MetricsService.ShipPageCount.Inc();
         initialized = false;
-        
-        if (CachedInstance is not null)
+
+        var cacheEntry = CacheService.GetOrDefault(CurrentTabId);
+        if (cacheEntry is not null)
         {
-            ViewModel = CachedInstance.ViewModel;
-            buildName = CachedInstance.buildName;
+            ViewModel = cacheEntry.ViewModel;
         }
         else
         {
             ViewModel = await LoadShipViewModel(ShipIndex);
-            await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToList(), new());   
+            await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToList(), new());
+            CacheService[CurrentTabId] = new(ViewModel);
         }
         
         initialized = true;
@@ -221,7 +210,7 @@
             {
                 build = Build.CreateBuildFromString(BuildString);
                 BuildString = null;
-                buildName = build.BuildName;
+                BuildName = build.BuildName;
             }
 
             var vm = await CreateViewModel(shipIndex, build, Localizer);
@@ -291,6 +280,7 @@
             {
                 ShipIndex = updateToShipSummary.Index;
                 ViewModel = await LoadShipViewModel(ShipIndex);
+                CacheService[CurrentTabId] = new(ViewModel);
                 await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToList(), new());
                 StateHasChanged();
             }
@@ -306,13 +296,13 @@
         var parameters = new DialogParameters
         {
             ["ShortLinkDisabled"] = !LinkShortener.IsAvailable,
-            ["BuildName"] = buildName,
+            ["BuildName"] = BuildName,
         };
         var dialog = await DialogService.ShowAsync<BuildShareDialog>(string.Empty, parameters, options);
         var result = await dialog.Result;
         if (!result.Canceled && result.Data is BuildShareResult shareResult)
         {
-            buildName = shareResult.BuildName;
+            BuildName = shareResult.BuildName;
             var build = ViewModel!.CreateBuild(shareResult.BuildName);
             var buildString = build.CreateShortStringFromBuild();
             var buildUrl = $"{NavManager.BaseUri}ship?shipIndexes={build.ShipIndex}&build={WebUtility.UrlEncode(buildString)}";
@@ -322,19 +312,19 @@
     
     private async Task SaveBuildStringToLocalStorage()
     {
-        await BuildHelper.StoreBuildContainers(new() { GetBuildHelperContainer() });
+        await BuildHelper.StoreBuildContainers(new() { GetBuildHelperContainer(CacheService[CurrentTabId]!) });
     }
 
-    public BuildHelper.BuildHelperContainer GetBuildHelperContainer()
+    public static BuildHelper.BuildHelperContainer GetBuildHelperContainer(VmCacheEntry cacheEntry)
     {
-        List<(string, float)>? modifiers = ViewModel?.UpgradePanelViewModel.GetModifierList();
-        modifiers?.AddRange(ViewModel?.ConsumableViewModel.GetModifiersList() ?? new List<(string, float)>());
-        modifiers?.AddRange(ViewModel?.CaptainSkillSelectorViewModel?.GetModifiersList() ?? new List<(string, float)>());
-        modifiers?.AddRange(ViewModel?.SignalSelectorViewModel?.GetModifierList() ?? new List<(string, float)>());
+        List<(string, float)> modifiers = cacheEntry.ViewModel.UpgradePanelViewModel.GetModifierList();
+        modifiers.AddRange(cacheEntry.ViewModel.ConsumableViewModel.GetModifiersList());
+        modifiers.AddRange(cacheEntry.ViewModel.CaptainSkillSelectorViewModel?.GetModifiersList() ?? new List<(string, float)>());
+        modifiers.AddRange(cacheEntry.ViewModel.SignalSelectorViewModel?.GetModifierList() ?? new List<(string, float)>());
         
-        var build = ViewModel!.CreateBuild(buildName);
+        var build = cacheEntry.ViewModel.CreateBuild(cacheEntry.BuildName);
         var buildString = build.CreateShortStringFromBuild();
-        BuildHelper.BuildHelperContainer container = new(build.ShipIndex, buildString, modifiers, ViewModel?.ConsumableViewModel.ActivatedSlots);
+        BuildHelper.BuildHelperContainer container = new(build.ShipIndex, buildString, modifiers, cacheEntry.ViewModel.ConsumableViewModel.ActivatedSlots);
         return container;
     }
 
@@ -348,10 +338,5 @@
         await vm.InitializeData(vmParams);
         
         return vm;
-    }
-
-    public string GetBuildName()
-    {
-        return buildName;
     }
 }

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -314,7 +314,7 @@
         return container;
     }
 
-    public async Task<ShipViewModel?> LoadShipVm(string shipIndex, string? buildString)
+    public async Task<ShipViewModel?> GetShipViewModel(string shipIndex, string? buildString)
     {
         BuildString = buildString;
         return await LoadShipViewModel(shipIndex);

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -57,7 +57,7 @@
             <MudPaper Outlined="true" Class="py-2 px-15">
                 <MudGrid Justify="Justify.Center">
                     <MudItem xs="12" md="2" Class="align-self-center d-flex justify-center">
-                        <MudTextField @bind-Value="BuildName" Label="Build:" Immediate Placeholder="Enter build name" Variant="Variant.Outlined" Margin="Margin.Dense"/>
+                        <MudTextField @bind-Value="BuildName" Label="Build:" Immediate Placeholder="Enter build name" Variant="Variant.Outlined" Margin="Margin.Dense" Validation="@(new Func<string, string?>(Validation.ValidateBuildName))"/>
                     </MudItem>
                     <MudItem xs="12" md="8" Class="@(GetShipAlign() + " d-flex justify-center")">
                         @if (ViewModel.PreviousShip is not null)

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -178,7 +178,7 @@
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
-        if (shipChanged && ViewModel is not null)
+        if (!firstRender && shipChanged && ViewModel is not null)
         {
             shipChanged = false;
             var elementIds = new List<string>();
@@ -191,10 +191,7 @@
             {
                 elementIds.AddRange(ViewModel.NextShips.Select(ship => CurrentTabId + "_" + ship.Index));
             }
-
-            // needed to prevent the script being run before the DOM has been loaded
-            await Task.Delay(1);
-
+            
             if (elementIds.Any())
             {
                 await MouseEventInterop.PreventMiddleClickDefaultBatched(elementIds);

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -42,7 +42,7 @@
                     <MudItem xs="12" md="8" Class="@(GetShipAlign() + " d-flex justify-center")">
                         @if (ViewModel.PreviousShip is not null)
                         {
-                            <MudStack Class="px-2 cursor-pointer" @onmouseup="@(args => UpdateToShip(args, CurrentTabId, ViewModel.PreviousShip))" AlignItems="AlignItems.Center" id="@(ViewModel.CurrentShipIndex + "_" + ViewModel.PreviousShip.Index)">
+                            <MudStack Class="px-2 cursor-pointer" @onmouseup="@(args => UpdateToShip(args, CurrentTabId, ViewModel.PreviousShip))" AlignItems="AlignItems.Center" id="@(ViewModel.CurrentShipIndex + "_" + ViewModel.PreviousShip.Index + "_" + CurrentTabId)">
                                 <MudImage Width="@GetImageWidth(false)" ObjectFit="ObjectFit.ScaleDown" Src="@(BaseAddress + ViewModel.PreviousShip.Index + ".png")"/>
                                 <MudStack Row="true" Justify="Justify.Center" Spacing="1">
                                     <MudIcon ViewBox="-1 0 24 10" Icon="@Helpers.GetIconFromClass(ViewModel.PreviousShip.ShipClass, ViewModel.PreviousShip.Category)"/>
@@ -61,7 +61,7 @@
                         {
                             foreach (var ship in ViewModel.NextShips)
                             {
-                                <MudStack key="@(ViewModel.CurrentShipIndex + "_" + ship.Index)" Class="px-2 cursor-pointer" @onmouseup="@(args => UpdateToShip(args, CurrentTabId, ship))" AlignItems="AlignItems.Center" id="@(ViewModel.CurrentShipIndex + "_" + ship.Index)">
+                                <MudStack key="@(ViewModel.CurrentShipIndex + "_" + ship.Index)" Class="px-2 cursor-pointer" @onmouseup="@(args => UpdateToShip(args, CurrentTabId, ship))" AlignItems="AlignItems.Center" id="@(ViewModel.CurrentShipIndex + "_" + ship.Index + "_" + CurrentTabId)">
                                     <MudImage Width="@GetImageWidth(false)" ObjectFit="ObjectFit.ScaleDown" Src="@(BaseAddress + ship.Index + ".png")"/>
                                     <MudStack Row="true" Justify="Justify.Center" Spacing="1">
                                         <MudIcon ViewBox="-1 0 24 10" Icon="@Helpers.GetIconFromClass(ship.ShipClass, ship.Category)"/>
@@ -72,7 +72,7 @@
                         }
                     </MudItem>
                     <MudItem xs="12" md="2" Class="align-self-center d-flex justify-center">
-                        <MudButton Size="Size.Large" Variant="Variant.Filled" Color="Color.Primary" FullWidth StartIcon="@Icons.Filled.Share" OnClick="@OnShareBuildClicked">
+                        <MudButton Size="Size.Large" Variant="Variant.Filled" Color="Color.Primary" FullWidth StartIcon="@Icons.Material.Filled.Share" OnClick="@OnShareBuildClicked">
                             @Localizer.GetAppLocalization(Translation.MainWindow_ShareBuild).Localization
                         </MudButton>
                     </MudItem>
@@ -129,6 +129,9 @@
 
     [Parameter]
     public string? BuildString { get; set; }
+    
+    [Parameter]
+    public ShipViewModel? CachedViewModel { get; set; }
 
     [CascadingParameter]
     private Breakpoint Breakpoint { get; set; }
@@ -149,7 +152,7 @@
         await base.OnInitializedAsync();
         MetricsService.ShipPageCount.Inc();
         initialized = false;
-        ViewModel = await LoadShipViewModel(ShipIndex);
+        ViewModel = CachedViewModel ?? await LoadShipViewModel(ShipIndex);
         await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToList(), new());
         initialized = true;
     }
@@ -163,14 +166,19 @@
             var elementIds = new List<string>();
             if (ViewModel.PreviousShip is not null)
             {
-                elementIds.Add(ViewModel.CurrentShipIndex + "_" + ViewModel.PreviousShip.Index);
+                elementIds.Add(ViewModel.CurrentShipIndex + "_" + ViewModel.PreviousShip.Index + "_" + CurrentTabId);
             }
             if (ViewModel.NextShips is not null)
             {
-                elementIds.AddRange(ViewModel.NextShips.Select(ship => ViewModel.CurrentShipIndex + "_" + ship.Index));
+                elementIds.AddRange(ViewModel.NextShips.Select(ship => ViewModel.CurrentShipIndex + "_" + ship.Index + "_" + CurrentTabId));
             }
+            
             StateHasChanged();
-            await MouseEventInterop.PreventMiddleClickDefaultBatched(elementIds);
+            
+            if (elementIds.Any())
+            {
+                await MouseEventInterop.PreventMiddleClickDefaultBatched(elementIds);
+            }
         }
     }
 
@@ -279,7 +287,7 @@
         };
         var dialog = DialogService.Show<BuildShareDialog>(string.Empty, parameters, options);
         var result = await dialog.Result;
-        if (!result.Cancelled && result.Data is BuildShareResult shareResult)
+        if (!result.Canceled && result.Data is BuildShareResult shareResult)
         {
             buildName = shareResult.BuildName;
             var build = ViewModel!.CreateBuild(shareResult.BuildName);

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -164,6 +164,7 @@
         if (cacheEntry is not null)
         {
             ViewModel = cacheEntry.ViewModel;
+            shipChanged = true;
         }
         else
         {

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -271,7 +271,6 @@
                 StateHasChanged();
             }
         }
-
     }
 
     private async Task OnShareBuildClicked()
@@ -299,10 +298,10 @@
     
     private async Task SaveBuildStringToLocalStorage()
     {
-        await BuildHelper.StoreBuildContainers(new() { GetBuildContainer() });
+        await BuildHelper.StoreBuildContainers(new() { GetBuildHelperContainer() });
     }
 
-    public BuildHelper.BuildHelperContainer GetBuildContainer()
+    public BuildHelper.BuildHelperContainer GetBuildHelperContainer()
     {
         List<(string, float)>? modifiers = ViewModel?.UpgradePanelViewModel.GetModifierList();
         modifiers?.AddRange(ViewModel?.ConsumableViewModel.GetModifiersList() ?? new List<(string, float)>());
@@ -311,7 +310,13 @@
         
         var build = ViewModel!.CreateBuild(buildName);
         var buildString = build.CreateShortStringFromBuild();
-        BuildHelper.BuildHelperContainer container = new(ShipIndex, buildString, modifiers, ViewModel?.ConsumableViewModel.ActivatedSlots);
+        BuildHelper.BuildHelperContainer container = new(build.ShipIndex, buildString, modifiers, ViewModel?.ConsumableViewModel.ActivatedSlots);
         return container;
+    }
+
+    public async Task<ShipViewModel?> LoadShipVm(string shipIndex, string? buildString)
+    {
+        BuildString = buildString;
+        return await LoadShipViewModel(shipIndex);
     }
 }

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -57,12 +57,12 @@
             <MudPaper Outlined="true" Class="py-2 px-15">
                 <MudGrid Justify="Justify.Center">
                     <MudItem xs="12" md="2" Class="align-self-center d-flex justify-center">
-                        <MudTextField @bind-Value="BuildName" Label="Build:" Immediate Placeholder="Enter build name" Variant="Variant.Outlined" Margin="Margin.Dense" Validation="@(new Func<string, string?>(Validation.ValidateBuildName))"/>
+                        <MudTextField @bind-Value="BuildName" Label="Build:" Immediate DebounceInterval="100" Placeholder="Enter build name" Variant="Variant.Outlined" Margin="Margin.Dense" Validation="@(new Func<string, string?>(Validation.ValidateBuildName))"/>
                     </MudItem>
                     <MudItem xs="12" md="8" Class="@(GetShipAlign() + " d-flex justify-center")">
                         @if (ViewModel.PreviousShip is not null)
                         {
-                            <MudStack Class="px-2 cursor-pointer" @onmouseup="@(args => UpdateToShip(args, CurrentTabId, ViewModel.PreviousShip))" AlignItems="AlignItems.Center" id="@(ViewModel.CurrentShipIndex + "_" + ViewModel.PreviousShip.Index + "_" + CurrentTabId)">
+                            <MudStack Class="px-2 cursor-pointer" @onmouseup="@(args => UpdateToShip(args, CurrentTabId, ViewModel.PreviousShip))" AlignItems="AlignItems.Center" id="@(CurrentTabId + "_" + ViewModel.PreviousShip.Index)">
                                 <MudImage Width="@GetImageWidth(false)" ObjectFit="ObjectFit.ScaleDown" Src="@(BaseAddress + ViewModel.PreviousShip.Index + ".png")"/>
                                 <MudStack Row="true" Justify="Justify.Center" Spacing="1">
                                     <MudIcon ViewBox="-1 0 24 10" Icon="@Helpers.GetIconFromClass(ViewModel.PreviousShip.ShipClass, ViewModel.PreviousShip.Category)"/>
@@ -81,7 +81,7 @@
                         {
                             foreach (var ship in ViewModel.NextShips)
                             {
-                                <MudStack key="@(ViewModel.CurrentShipIndex + "_" + ship.Index)" Class="px-2 cursor-pointer" @onmouseup="@(args => UpdateToShip(args, CurrentTabId, ship))" AlignItems="AlignItems.Center" id="@(ViewModel.CurrentShipIndex + "_" + ship.Index + "_" + CurrentTabId)">
+                                <MudStack key="@(CurrentTabId + "_" + ship.Index)" Class="px-2 cursor-pointer" @onmouseup="@(args => UpdateToShip(args, CurrentTabId, ship))" AlignItems="AlignItems.Center" id="@(CurrentTabId + "_" + ship.Index)">
                                     <MudImage Width="@GetImageWidth(false)" ObjectFit="ObjectFit.ScaleDown" Src="@(BaseAddress + ship.Index + ".png")"/>
                                     <MudStack Row="true" Justify="Justify.Center" Spacing="1">
                                         <MudIcon ViewBox="-1 0 24 10" Icon="@Helpers.GetIconFromClass(ship.ShipClass, ship.Category)"/>
@@ -184,15 +184,17 @@
             var elementIds = new List<string>();
             if (ViewModel.PreviousShip is not null)
             {
-                elementIds.Add(ViewModel.CurrentShipIndex + "_" + ViewModel.PreviousShip.Index + "_" + CurrentTabId);
+                elementIds.Add(CurrentTabId + "_" + ViewModel.PreviousShip.Index);
             }
+            
             if (ViewModel.NextShips is not null)
             {
-                elementIds.AddRange(ViewModel.NextShips.Select(ship => ViewModel.CurrentShipIndex + "_" + ship.Index + "_" + CurrentTabId));
+                elementIds.AddRange(ViewModel.NextShips.Select(ship => CurrentTabId + "_" + ship.Index));
             }
-            
-            StateHasChanged();
-            
+
+            // needed to prevent the script being run before the DOM has been loaded
+            await Task.Delay(1);
+
             if (elementIds.Any())
             {
                 await MouseEventInterop.PreventMiddleClickDefaultBatched(elementIds);

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -152,8 +152,17 @@
         await base.OnInitializedAsync();
         MetricsService.ShipPageCount.Inc();
         initialized = false;
-        ViewModel = CachedViewModel ?? await LoadShipViewModel(ShipIndex);
-        await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToList(), new());
+        
+        if (CachedViewModel is not null)
+        {
+            ViewModel = CachedViewModel;
+        }
+        else
+        {
+            ViewModel = await LoadShipViewModel(ShipIndex);
+            await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToList(), new());   
+        }
+        
         initialized = true;
     }
 

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -156,7 +156,7 @@
         if (CachedInstance is not null)
         {
             ViewModel = CachedInstance.ViewModel;
-            buildName = CachedInstance.buildName ;
+            buildName = CachedInstance.buildName;
         }
         else
         {

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -10,7 +10,6 @@
 @using WoWsShipBuilder.Web.Dialogs
 @using System.Net
 @using System.Diagnostics
-@using Microsoft.Extensions.Caching.Memory
 @using WoWsShipBuilder.Core.Builds
 @using WoWsShipBuilder.Core.DataContainers
 @using WoWsShipBuilder.Core.Extensions
@@ -134,7 +133,7 @@
     public string? BuildString { get; set; }
 
     [Parameter, EditorRequired]
-    public VmCacheService CacheService { get; set; } = default!;
+    public VmCache Cache { get; set; } = default!;
 
     [CascadingParameter]
     private Breakpoint Breakpoint { get; set; }
@@ -150,8 +149,8 @@
 
     private string BuildName
     {
-        get => CacheService[CurrentTabId]?.BuildName ?? string.Empty;
-        set => CacheService[CurrentTabId]!.BuildName = value;
+        get => Cache[CurrentTabId]!.BuildName;
+        set => Cache[CurrentTabId]!.BuildName = value;
     }
 
     protected override async Task OnInitializedAsync()
@@ -160,7 +159,7 @@
         MetricsService.ShipPageCount.Inc();
         initialized = false;
 
-        var cacheEntry = CacheService.GetOrDefault(CurrentTabId);
+        var cacheEntry = Cache.GetOrDefault(CurrentTabId);
         if (cacheEntry is not null)
         {
             ViewModel = cacheEntry.ViewModel;
@@ -170,7 +169,7 @@
         {
             ViewModel = await LoadShipViewModel(ShipIndex);
             await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToList(), new());
-            CacheService[CurrentTabId] = new(ViewModel);
+            Cache[CurrentTabId] = new(ViewModel);
         }
         
         initialized = true;
@@ -280,7 +279,7 @@
             {
                 ShipIndex = updateToShipSummary.Index;
                 ViewModel = await LoadShipViewModel(ShipIndex);
-                CacheService[CurrentTabId] = new(ViewModel);
+                Cache[CurrentTabId] = new(ViewModel);
                 await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToList(), new());
                 StateHasChanged();
             }
@@ -312,7 +311,7 @@
     
     private async Task SaveBuildStringToLocalStorage()
     {
-        await BuildHelper.StoreBuildContainers(new() { GetBuildHelperContainer(CacheService[CurrentTabId]!) });
+        await BuildHelper.StoreBuildContainers(new() { GetBuildHelperContainer(Cache[CurrentTabId]!) });
     }
 
     public static BuildHelper.BuildHelperContainer GetBuildHelperContainer(VmCacheEntry cacheEntry)

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -129,9 +129,9 @@
 
     [Parameter]
     public string? BuildString { get; set; }
-    
+
     [Parameter]
-    public ShipViewModel? CachedViewModel { get; set; }
+    public ShipStatsContainer? CachedInstance { get; set; }
 
     [CascadingParameter]
     private Breakpoint Breakpoint { get; set; }
@@ -153,9 +153,10 @@
         MetricsService.ShipPageCount.Inc();
         initialized = false;
         
-        if (CachedViewModel is not null)
+        if (CachedInstance is not null)
         {
-            ViewModel = CachedViewModel;
+            ViewModel = CachedInstance.ViewModel;
+            buildName = CachedInstance.buildName ;
         }
         else
         {
@@ -327,5 +328,10 @@
     {
         BuildString = buildString;
         return await LoadShipViewModel(shipIndex);
+    }
+
+    public string GetBuildName()
+    {
+        return buildName;
     }
 }

--- a/WoWsShipBuilder.Web/Components/ShipUpgradeSelector.razor
+++ b/WoWsShipBuilder.Web/Components/ShipUpgradeSelector.razor
@@ -39,11 +39,11 @@
                                                 <MudText Align="Align.Center" Typo="Typo.body2" Style="white-space: break-spaces">@Localizer.GetGameLocalization("DESC_" + currentMod.Name).Localization</MudText>
                                             }
                                             <MudDivider Light="true" Class="ma-1"/>
-                                            @foreach ((string modifierName, double modifierValue) in currentMod.Effect)
+                                            foreach ((string modifierName, double modifierValue) in currentMod.Effect)
                                             {
                                                 // this is here so we can have the call to the ModifierProcessor only once, to share the value between the if and the mudtext
                                                 string modifier = ModifierProcessor.GetUiModifierString(modifierName, modifierValue, ReturnFilter.All, Localizer);
-                                                @if (!string.IsNullOrWhiteSpace(modifier))
+                                                if (!string.IsNullOrWhiteSpace(modifier))
                                                 {
                                                     <MudText Align="Align.Start" Typo="Typo.body2" Style="white-space: break-spaces" Class="flex-grow-0 flex-shrink-1">@modifier</MudText>
                                                 }
@@ -60,7 +60,7 @@
                             @foreach (var modernization in columnModernizations)
                             {
                                 <MudMenuItem Style="padding: 2px 4px;" OnClick="@(_ => ViewModel.OnModernizationSelected(modernization, columnModernizations))">
-                                     <MudTooltip Color="Color.Transparent" Placement="Placement.Right" Delay="400">
+                                    <MudTooltip Color="Color.Transparent" Placement="Placement.Right" Delay="400">
                                         <ChildContent>
                                             <MudImage Width="@GetImageSize(true)" Height="@GetImageSize(true)" Src="@GetUpgradeIcon(modernization)"/>
                                         </ChildContent>
@@ -80,20 +80,22 @@
                                                             <MudText Align="Align.Center" Typo="Typo.body2" Style="white-space: break-spaces">@Localizer.GetGameLocalization("DESC_" + modernization.Name).Localization</MudText>
                                                         }
                                                         <MudDivider Light="true" Class="ma-1"/>
-                                                        @foreach ((string modifierName, double modifierValue) in modernization.Effect)
+                                                        foreach ((string modifierName, double modifierValue) in modernization.Effect)
                                                         {
                                                             // this is here so we can have the call to the ModifierProcessor only once, to share the value between the if and the mudtext
                                                             string modifier = ModifierProcessor.GetUiModifierString(modifierName, modifierValue, ReturnFilter.All, Localizer);
-                                                            @if (!string.IsNullOrWhiteSpace(modifier))
+                                                            if (!string.IsNullOrWhiteSpace(modifier))
                                                             {
-                                                                <MudText Align="Align.Left" Typo="Typo.body2" Style="white-space: break-spaces" Class="flex-grow-0 flex-shrink-1">@modifier</MudText>
+                                                                <MudText Align="Align.Left" Typo="Typo.body2" Style="white-space: break-spaces" Class="flex-grow-0 flex-shrink-1">
+                                                                    @modifier
+                                                                </MudText>
                                                             }
                                                         }
                                                     }
                                                 </MudStack>
                                             </MudPaper>
                                         </TooltipContent>
-                                    </MudTooltip>
+                                   </MudTooltip>
                                 </MudMenuItem>
                             }
                         </MudPaper>
@@ -115,7 +117,7 @@
         Modernization? selectedMod = modernizations.FirstOrDefault(modernization => selectedModernizations.Any(selected => selected.Index.Equals(modernization.Index)));
         selectedMod ??= UpgradePanelViewModelBase.PlaceholderModernization;
 
-        string path = selectedMod.Index != null ? $"/assets/modernization_icons/icon_modernization_{selectedMod.Name}.png" : $"/assets/modernization_icons/modernization_default3.png";
+        string path = selectedMod.Index != null ? $"/assets/modernization_icons/icon_modernization_{selectedMod.Name}.png" : "/assets/modernization_icons/modernization_default3.png";
 
         return path;
     }
@@ -128,7 +130,7 @@
     
     private string GetUpgradeIcon(Modernization modernization)
     {
-        return modernization.Index != null ? $"/assets/modernization_icons/icon_modernization_{modernization.Name}.png" : $"/assets/modernization_icons/modernization_default3.png";
+        return modernization.Index != null ? $"/assets/modernization_icons/icon_modernization_{modernization.Name}.png" : "/assets/modernization_icons/modernization_default3.png";
     }
     
     private int GetImageSize(bool isInTooltip)

--- a/WoWsShipBuilder.Web/Components/TopMenu.razor
+++ b/WoWsShipBuilder.Web/Components/TopMenu.razor
@@ -63,16 +63,16 @@
         </MudDrawerHeader>
         <MudNavMenu Bordered Color="Color.Info">
             <MudNavLink Icon="@shipBuilderIcon" Match="NavLinkMatch.All" Href="/">Homepage</MudNavLink>
-            <MudNavLink Icon="@Icons.Filled.SsidChart" Href="/acceleration-charts" ActiveClass="nav-link-active">Acceleration Charts</MudNavLink>
+            <MudNavLink Icon="@Icons.Material.Filled.SsidChart" Href="/acceleration-charts" ActiveClass="nav-link-active">Acceleration Charts</MudNavLink>
             @if (shipComparisonEnabled)
             {
-                <MudNavLink Icon="@Icons.Filled.SsidChart" Href="/comparison" ActiveClass="nav-link-active">Ship Comparison</MudNavLink>
+                <MudNavLink Icon="@Icons.Material.Filled.SsidChart" Href="/comparison" ActiveClass="nav-link-active">Ship Comparison</MudNavLink>
             }
-            <MudNavLink Icon="@Icons.Filled.SsidChart" Href="/charts">Dispersion and Ballistic Charts</MudNavLink>
+            <MudNavLink Icon="@Icons.Material.Filled.SsidChart" Href="/charts">Dispersion and Ballistic Charts</MudNavLink>
             <MudNavLink Icon="@kofiIcon" Href="https://ko-fi.com/L4L3DT7EM" Target="_blank">Donate</MudNavLink>
             @* <MudNavLink Icon="@Icons.Filled.Science" Href="/test">Test page</MudNavLink> *@
             <MudDivider Class="my-4"/>
-            <MudNavLink Icon="@Icons.Filled.Settings" Href="/settings">@Localizer.GetAppLocalization(nameof(Translation.SettingsWindow_Settings)).Localization</MudNavLink>
+            <MudNavLink Icon="@Icons.Material.Filled.Settings" Href="/settings">@Localizer.GetAppLocalization(nameof(Translation.SettingsWindow_Settings)).Localization</MudNavLink>
             <MudDivider Class="my-4"/>
             <MudNavLink Style="text-transform: none !important;" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/WoWs-Builder-Team/WoWs-ShipBuilder#wows-shipbuilder" Target="_blank">GitHub Repository</MudNavLink>
             <MudDivider Class="my-4"/>

--- a/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
@@ -2,7 +2,6 @@
 @using Prometheus
 @using WoWsShipBuilder.Core.Services
 @using System.Collections.Concurrent
-@using Microsoft.AspNetCore.WebUtilities
 @using Microsoft.Extensions.Options
 @using WoWsShipBuilder.Core.Builds
 @using WoWsShipBuilder.Core.Data
@@ -326,66 +325,23 @@
             // in this case there is no need to run the validation again since there were no changes to the input. Needed because validation is called also when the text field looses focus.
             return inputBuildStringValidationResultCache;
         }
-        
+
         inputBuildStringCache = buildStr;
         buildString = string.Empty;
+
+        var validationResult = await Validation.ValidateBuildString(buildStr, SelectedContainer.Ship.Index, Localizer, LinkShorteningOptions.Value.UriPrefix);
         
-        if (string.IsNullOrWhiteSpace(buildStr))
+        if (validationResult.IsValidBuildString)
         {
-            inputBuildStringValidationResultCache = null;
-            return inputBuildStringValidationResultCache;
-        }
-        
-        if (buildStr.Contains(LinkShorteningOptions.Value.UriPrefix))
-        {
-            string? longUrl = await Helpers.RetrieveLongUrl(buildStr);
-            
-            if (longUrl is not null && QueryHelpers.ParseQuery(longUrl).TryGetValue("build", out var buildStrFromUrl))
-            {
-                buildStr = buildStrFromUrl.ToString(); 
-            }
-            else
-            {
-                inputBuildStringValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
-                return inputBuildStringValidationResultCache;
-            }
+            buildString = validationResult.ValidationMessage!;
+
+            await Task.Delay(1);
+            StateHasChanged();
+            await Task.Delay(1);
+
+            return inputBuildStringValidationResultCache = null;
         }
 
-        if (QueryHelpers.ParseQuery(buildStr).TryGetValue("build", out var buildStringFromUrl))
-        {
-            buildStr = buildStringFromUrl.ToString();
-        }
-
-        // this is needed to avoid executing the try/catch even when we already know it is going to fail and so get a better performance
-        if (buildStr.Contains(';'))
-        {
-            try
-            {
-                var build = Build.CreateBuildFromString(buildStr);
-                if (SelectedContainer.Ship.Index.Equals(build.ShipIndex))
-                {
-                    buildString = buildStr;
-                    
-                    // needed to update UI
-                    await Task.Delay(1);
-                    StateHasChanged();
-                    await Task.Delay(1);
-                    
-                    inputBuildStringValidationResultCache = null;
-                    return inputBuildStringValidationResultCache;
-                }
-                
-                inputBuildStringValidationResultCache = $"{Localizer.SimpleAppLocalization(nameof(Translation.Validation_Incompatibility))}. {Localizer.SimpleAppLocalization(nameof(Translation.Validation_SelectedShip))}: {Localizer.GetGameLocalization(SelectedContainer.Ship.Index + "_FULL").Localization} ≠ {Localizer.SimpleAppLocalization(nameof(Translation.Validation_ShipInBuild))}: {Localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}";
-                return inputBuildStringValidationResultCache;
-            }
-            catch (FormatException)
-            {
-                inputBuildStringValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
-                return inputBuildStringValidationResultCache;
-            }
-        }
-
-        inputBuildStringValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
-        return inputBuildStringValidationResultCache;
+        return inputBuildStringValidationResultCache = validationResult.ValidationMessage;
     }
 }

--- a/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
@@ -332,6 +332,7 @@
         
         buildString = validationResult.ValidatedBuildString;
 
+        // needed to update UI
         await Task.Delay(1);
         StateHasChanged();
         await Task.Delay(1);

--- a/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
@@ -2,6 +2,7 @@
 @using Prometheus
 @using WoWsShipBuilder.Core.Services
 @using System.Collections.Concurrent
+@using System.Net
 @using WoWsShipBuilder.Core.Builds
 @using WoWsShipBuilder.Core.Data
 @using WoWsShipBuilder.Core.Extensions
@@ -125,6 +126,8 @@
     private MudTabs desktopTabs = default!;
 
     private object selectedListValue = 0;
+    
+    private bool validBuildString;
 
     public BuildConfigurationDialog()
     {
@@ -180,8 +183,8 @@
                             </MudItem>
                             <MudItem xs="12" md="6">
                                 <MudStack Row="true" Class="mt-n1 mb-0">
-                                    <MudTextField @bind-Value="currentBuildString" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Filled.Edit" Label="Alternative" Placeholder="@Localizer.SimpleAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink))" Variant="Variant.Outlined"/>
-                                    <MudButton Disabled="@string.IsNullOrWhiteSpace(currentBuildString)" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" Style="margin-top: 6px" OnClick="async () => await ImportBuild(SelectedContainer.Ship)">
+                                    <MudTextField @bind-Value="currentBuildString" Immediate Validation="@(new Func<string, string?>(ValidateBuildString))" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Filled.Edit" Label="Alternative" Placeholder="@Localizer.SimpleAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink))" Variant="Variant.Outlined"/>
+                                    <MudButton Disabled="@(string.IsNullOrWhiteSpace(currentBuildString) && !validBuildString)" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" Style="margin-top: 6px" OnClick="async () => await ImportBuild(SelectedContainer.Ship)">
                                         Import
                                     </MudButton>
                                 </MudStack>
@@ -271,7 +274,7 @@
 
     private async Task ResetBuild()
     {
-        var vm = LoadShipViewModel(SelectedContainer with {Build = null, ActivatedConsumableSlots = null, SpecialAbilityActive = false });
+        var vm = LoadShipViewModel(SelectedContainer with { Build = null, ActivatedConsumableSlots = null, SpecialAbilityActive = false });
         ViewModel = vm;
         vmCache[SelectedContainer.Id] = vm;
         await Task.Delay(1); // needed for the captain skill selector to rerender properly
@@ -279,9 +282,20 @@
 
     private async Task ImportBuild(Ship ship)
     {
+        string buildStr;
+        if (currentBuildString.Contains("build="))
+        {
+            int index = currentBuildString.IndexOf("build=", StringComparison.Ordinal);
+            buildStr = WebUtility.UrlDecode(currentBuildString[(index + 6)..]);
+        }
+        else
+        {
+            buildStr = currentBuildString;
+        }
+        
         try
         {
-            ViewModel = LoadShipViewModel(ShipBuildContainer.CreateNew(ship, Build.CreateBuildFromString(currentBuildString), null));
+            ViewModel = LoadShipViewModel(ShipBuildContainer.CreateNew(ship, Build.CreateBuildFromString(buildStr), null));
             currentBuildString = string.Empty;
             vmCache[SelectedContainer.Id] = ViewModel;
             Snackbar.Add("Build successfully imported", Severity.Success);
@@ -306,5 +320,60 @@
         currentBuildString = string.Empty;
         selectedTab = newIndex;
         UpdateViewModel();
+    }
+    
+    private string? ValidateBuildString(string buildStr)
+    {
+        validBuildString = false;
+        if (string.IsNullOrWhiteSpace(buildStr))
+        {
+            return null;
+        }
+        
+        if (buildStr.Contains("share.wowssb.com"))
+        {
+            return "Short links are not supported";
+        }
+        
+        if (buildStr.Contains(";"))
+        {
+            try
+            {
+                var build = Build.CreateBuildFromString(buildStr);
+                if (SelectedContainer.Ship.Index.Equals(build.ShipIndex))
+                {
+                    validBuildString = true;
+                    return null;
+                }
+                
+                return $"Incompatibility: Selected Ship: {Localizer.GetGameLocalization(SelectedContainer.Ship.Index + "_FULL").Localization} ≠ Ship in Build: {Localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}";
+            }
+            catch (FormatException)
+            {
+                return "Invalid build";
+            }
+        }
+        
+        if (buildStr.Contains("&build="))
+        {
+            int index = buildStr.IndexOf("build=", StringComparison.Ordinal);
+            string decodedBuildString = WebUtility.UrlDecode(buildStr[(index + 6)..]);
+            try
+            {
+                var build = Build.CreateBuildFromString(decodedBuildString);
+                if (SelectedContainer.Ship.Index.Equals(build.ShipIndex))
+                {
+                    validBuildString = true;
+                    return null;
+                }
+                return $"Incompatibility: Selected Ship: {Localizer.GetGameLocalization(SelectedContainer.Ship.Index + "_FULL").Localization} ≠ Ship in Build: {Localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}";
+            }
+            catch (FormatException)
+            {
+                return "Invalid build";
+            }
+        }
+        
+        return "Invalid build";
     }
 }

--- a/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
@@ -327,20 +327,14 @@
         }
 
         inputBuildStringCache = buildStr;
-        buildString = string.Empty;
-
+        
         var validationResult = await Validation.ValidateBuildString(buildStr, SelectedContainer.Ship.Index, Localizer, LinkShorteningOptions.Value.UriPrefix);
         
-        if (validationResult.IsValidBuildString)
-        {
-            buildString = validationResult.ValidationMessage!;
+        buildString = validationResult.ValidatedBuildString;
 
-            await Task.Delay(1);
-            StateHasChanged();
-            await Task.Delay(1);
-
-            return inputBuildStringValidationResultCache = null;
-        }
+        await Task.Delay(1);
+        StateHasChanged();
+        await Task.Delay(1);
 
         return inputBuildStringValidationResultCache = validationResult.ValidationMessage;
     }

--- a/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
@@ -187,7 +187,7 @@
                                 </MudStack>
                             </MudItem>
                             <MudItem xs="12" md="6">
-                                <MudTextField @bind-Value="ViewModel.BuildName" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Filled.Edit" Label="Build Name" Placeholder="Enter build name" Variant="Variant.Outlined" Class="mt-auto mb-0"/>
+                                <MudTextField @bind-Value="ViewModel.BuildName" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Edit" Label="Build Name" Placeholder="Enter build name" Variant="Variant.Outlined" Class="mt-auto mb-0"/>
                             </MudItem>
                         }
                         else

--- a/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
@@ -19,7 +19,7 @@
 @inject ISnackbar Snackbar
 @inject IOptions<LinkShorteningOptions> LinkShorteningOptions
 
-<MudDialog Style="overflow-y: auto; max-height: 100vh;">
+<MudDialog Style="overflow-y: auto; max-height: 102vh;">
     <DialogContent>
         <MudBreakpointProvider>
             <MudHidden Breakpoint="Breakpoint.MdAndUp" Invert="true">
@@ -83,7 +83,7 @@
                  @Localizer.GetAppLocalization(nameof(Translation.MainWindow_ResetBuild)).Localization
             </MudText>
         </MudButton>
-        <MudButton Color="Color.Success" OnClick="@SaveBuilds" Variant="Variant.Filled">
+        <MudButton Color="Color.Success" OnClick="@SaveBuilds" Variant="Variant.Filled" Disabled="@(ViewModel!.BuildName.Intersect(Path.GetInvalidFileNameChars()).Any() || ViewModel!.BuildName.Contains(';'))">
             <MudText Typo="Typo.button">
                  @Localizer.GetAppLocalization(nameof(Translation.ShipSelectionWindow_ConfirmButton)).Localization
             </MudText>
@@ -189,14 +189,14 @@
                             </MudItem>
                             <MudItem xs="12" md="6">
                                 <MudStack Row="true" Class="mt-n1 mb-0">
-                                    <MudTextField @bind-Value="inputBuildString" Immediate Validation="@(new Func<string, Task<string?>>(ValidateBuildString))" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Edit" Label="Alternative" Placeholder="@Localizer.SimpleAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink))" Variant="Variant.Outlined"/>
+                                    <MudTextField @bind-Value="inputBuildString" Immediate DebounceInterval="100" Validation="@(new Func<string, Task<string?>>(ValidateBuildString))" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Edit" Label="Alternative" Placeholder="@Localizer.SimpleAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink))" Variant="Variant.Outlined"/>
                                     <MudButton Disabled="@(string.IsNullOrWhiteSpace(buildString))" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" Style="margin-top: 6px" OnClick="async () => await ImportBuild(SelectedContainer.Ship)">
                                         @Localizer.GetAppLocalization(Translation.BuildImport_Import).Localization
                                     </MudButton>
                                 </MudStack>
                             </MudItem>
                             <MudItem xs="12" md="6">
-                                <MudTextField @bind-Value="ViewModel.BuildName" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Edit" Label="Build Name" Placeholder="Enter build name" Variant="Variant.Outlined" Class="mt-auto mb-0"/>
+                                <MudTextField @bind-Value="ViewModel.BuildName" Immediate Validation="@(new Func<string, string?>(Validation.ValidateBuildName))" DebounceInterval="100" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Edit" Label="Build Name" Placeholder="Enter build name" Variant="Variant.Outlined" Class="mt-auto mb-0"/>
                             </MudItem>
                         }
                         else
@@ -336,7 +336,7 @@
         await Task.Delay(1);
         StateHasChanged();
         await Task.Delay(1);
-
+        
         return inputBuildStringValidationResultCache = validationResult.ValidationMessage;
     }
 }

--- a/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
@@ -2,12 +2,14 @@
 @using Prometheus
 @using WoWsShipBuilder.Core.Services
 @using System.Collections.Concurrent
-@using System.Net
+@using Microsoft.AspNetCore.WebUtilities
+@using Microsoft.Extensions.Options
 @using WoWsShipBuilder.Core.Builds
 @using WoWsShipBuilder.Core.Data
 @using WoWsShipBuilder.Core.Extensions
 @using WoWsShipBuilder.DataStructures.Ship
 @using WoWsShipBuilder.ViewModels.Other
+@using WoWsShipBuilder.Web.LinkShortening
 @using WoWsShipBuilder.Web.Utility
 
 @inherits ReactiveComponentBase<ShipBuildViewModel>
@@ -16,6 +18,7 @@
 @inject IMetricsService MetricsService
 @inject IHostEnvironment Environment
 @inject ISnackbar Snackbar
+@inject IOptions<LinkShorteningOptions> LinkShorteningOptions
 
 <MudDialog Style="overflow-y: auto; max-height: 100vh;">
     <DialogContent>
@@ -117,7 +120,7 @@
 
     private readonly ConcurrentDictionary<Guid, ShipBuildViewModel> vmCache = new();
 
-    private string currentBuildString = string.Empty;
+    private string inputBuildString = string.Empty;
 
     private readonly Dictionary<Guid, string> buildNameDictionary = new();
 
@@ -126,8 +129,12 @@
     private MudTabs desktopTabs = default!;
 
     private object selectedListValue = 0;
+
+    private string inputBuildStringCache = string.Empty;
     
-    private bool validBuildString;
+    private string? inputBuildStringValidationResultCache;
+
+    private string buildString = string.Empty;
 
     public BuildConfigurationDialog()
     {
@@ -183,8 +190,8 @@
                             </MudItem>
                             <MudItem xs="12" md="6">
                                 <MudStack Row="true" Class="mt-n1 mb-0">
-                                    <MudTextField @bind-Value="currentBuildString" Immediate Validation="@(new Func<string, string?>(ValidateBuildString))" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Filled.Edit" Label="Alternative" Placeholder="@Localizer.SimpleAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink))" Variant="Variant.Outlined"/>
-                                    <MudButton Disabled="@(string.IsNullOrWhiteSpace(currentBuildString) && !validBuildString)" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" Style="margin-top: 6px" OnClick="async () => await ImportBuild(SelectedContainer.Ship)">
+                                    <MudTextField @bind-Value="inputBuildString" Immediate Validation="@(new Func<string, Task<string?>>(ValidateBuildString))" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Edit" Label="Alternative" Placeholder="@Localizer.SimpleAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink))" Variant="Variant.Outlined"/>
+                                    <MudButton Disabled="@(string.IsNullOrWhiteSpace(buildString))" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" Style="margin-top: 6px" OnClick="async () => await ImportBuild(SelectedContainer.Ship)">
                                         @Localizer.GetAppLocalization(Translation.BuildImport_Import).Localization
                                     </MudButton>
                                 </MudStack>
@@ -282,21 +289,11 @@
 
     private async Task ImportBuild(Ship ship)
     {
-        string buildStr;
-        if (currentBuildString.Contains("build="))
-        {
-            int index = currentBuildString.IndexOf("build=", StringComparison.Ordinal);
-            buildStr = WebUtility.UrlDecode(currentBuildString[(index + 6)..]);
-        }
-        else
-        {
-            buildStr = currentBuildString;
-        }
-        
         try
         {
-            ViewModel = LoadShipViewModel(ShipBuildContainer.CreateNew(ship, Build.CreateBuildFromString(buildStr), null));
-            currentBuildString = string.Empty;
+            ViewModel = LoadShipViewModel(ShipBuildContainer.CreateNew(ship, Build.CreateBuildFromString(buildString), null));
+            inputBuildString = string.Empty;
+            buildString = string.Empty;
             vmCache[SelectedContainer.Id] = ViewModel;
             Snackbar.Add("Build successfully imported", Severity.Success);
             await Task.Delay(1); // needed for the captain skill selector to rerender properly
@@ -317,63 +314,78 @@
         buildNameDictionary[SelectedContainer.Id] = string.IsNullOrEmpty(ViewModel!.BuildName) ? ShipComparisonViewModel.DefaultBuildName : ViewModel.BuildName;
         ViewModel = null;
         StateHasChanged();
-        currentBuildString = string.Empty;
+        inputBuildString = string.Empty;
         selectedTab = newIndex;
         UpdateViewModel();
     }
-    
-    private string? ValidateBuildString(string buildStr)
+
+    private async Task<string?> ValidateBuildString(string buildStr)
     {
-        validBuildString = false;
+        if (buildStr.Equals(inputBuildStringCache))
+        {
+            // in this case there is no need to run the validation again since there were no changes to the input. Needed because validation is called also when the text field looses focus.
+            return inputBuildStringValidationResultCache;
+        }
+        
+        inputBuildStringCache = buildStr;
+        buildString = string.Empty;
+        
         if (string.IsNullOrWhiteSpace(buildStr))
         {
-            return null;
+            inputBuildStringValidationResultCache = null;
+            return inputBuildStringValidationResultCache;
         }
         
-        if (buildStr.Contains("share.wowssb.com"))
+        if (buildStr.Contains(LinkShorteningOptions.Value.UriPrefix))
         {
-            return "Short links are not supported";
+            string? longUrl = await Helpers.RetrieveLongUrl(buildStr);
+            
+            if (longUrl is not null && QueryHelpers.ParseQuery(longUrl).TryGetValue("build", out var buildStrFromUrl))
+            {
+                buildStr = buildStrFromUrl.ToString(); 
+            }
+            else
+            {
+                inputBuildStringValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
+                return inputBuildStringValidationResultCache;
+            }
         }
-        
-        if (buildStr.Contains(";"))
+
+        if (QueryHelpers.ParseQuery(buildStr).TryGetValue("build", out var buildStringFromUrl))
+        {
+            buildStr = buildStringFromUrl.ToString();
+        }
+
+        // this is needed to avoid executing the try/catch even when we already know it is going to fail and so get a better performance
+        if (buildStr.Contains(';'))
         {
             try
             {
                 var build = Build.CreateBuildFromString(buildStr);
                 if (SelectedContainer.Ship.Index.Equals(build.ShipIndex))
                 {
-                    validBuildString = true;
-                    return null;
+                    buildString = buildStr;
+                    
+                    // needed to update UI
+                    await Task.Delay(1);
+                    StateHasChanged();
+                    await Task.Delay(1);
+                    
+                    inputBuildStringValidationResultCache = null;
+                    return inputBuildStringValidationResultCache;
                 }
                 
-                return $"Incompatibility: Selected Ship: {Localizer.GetGameLocalization(SelectedContainer.Ship.Index + "_FULL").Localization} ≠ Ship in Build: {Localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}";
+                inputBuildStringValidationResultCache = $"{Localizer.SimpleAppLocalization(nameof(Translation.Validation_Incompatibility))}. {Localizer.SimpleAppLocalization(nameof(Translation.Validation_SelectedShip))}: {Localizer.GetGameLocalization(SelectedContainer.Ship.Index + "_FULL").Localization} ≠ {Localizer.SimpleAppLocalization(nameof(Translation.Validation_ShipInBuild))}: {Localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}";
+                return inputBuildStringValidationResultCache;
             }
             catch (FormatException)
             {
-                return "Invalid build";
+                inputBuildStringValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
+                return inputBuildStringValidationResultCache;
             }
         }
-        
-        if (buildStr.Contains("&build="))
-        {
-            int index = buildStr.IndexOf("build=", StringComparison.Ordinal);
-            string decodedBuildString = WebUtility.UrlDecode(buildStr[(index + 6)..]);
-            try
-            {
-                var build = Build.CreateBuildFromString(decodedBuildString);
-                if (SelectedContainer.Ship.Index.Equals(build.ShipIndex))
-                {
-                    validBuildString = true;
-                    return null;
-                }
-                return $"Incompatibility: Selected Ship: {Localizer.GetGameLocalization(SelectedContainer.Ship.Index + "_FULL").Localization} ≠ Ship in Build: {Localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}";
-            }
-            catch (FormatException)
-            {
-                return "Invalid build";
-            }
-        }
-        
-        return "Invalid build";
+
+        inputBuildStringValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
+        return inputBuildStringValidationResultCache;
     }
 }

--- a/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialog.razor
@@ -185,7 +185,7 @@
                                 <MudStack Row="true" Class="mt-n1 mb-0">
                                     <MudTextField @bind-Value="currentBuildString" Immediate Validation="@(new Func<string, string?>(ValidateBuildString))" Clearable="true" FullWidth="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Filled.Edit" Label="Alternative" Placeholder="@Localizer.SimpleAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink))" Variant="Variant.Outlined"/>
                                     <MudButton Disabled="@(string.IsNullOrWhiteSpace(currentBuildString) && !validBuildString)" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" Style="margin-top: 6px" OnClick="async () => await ImportBuild(SelectedContainer.Ship)">
-                                        Import
+                                        @Localizer.GetAppLocalization(Translation.BuildImport_Import).Localization
                                     </MudButton>
                                 </MudStack>
                             </MudItem>

--- a/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialogHelper.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildConfigurationDialogHelper.razor
@@ -39,7 +39,7 @@
             ["Ships"] = shipBuildContainers,
         };
         
-        var dialogResult = await DialogService.Show<BuildConfigurationDialog>("Configure builds", parameters, options).Result;
+        var dialogResult = await (await DialogService.ShowAsync<BuildConfigurationDialog>("Configure builds", parameters, options)).Result;
         if (dialogResult.Data is List<ShipBuildContainer> buildContainers)
         {
             return buildContainers;

--- a/WoWsShipBuilder.Web/Dialogs/BuildStringInputDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildStringInputDialog.razor
@@ -7,7 +7,7 @@
 <MudDialog Style="width: 600px">
     <DialogContent>
         <MudFocusTrap DefaultFocus="DefaultFocus.FirstChild">
-            <MudTextField @bind-Value="inputBuild" Label="@Localizer.GetAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink)).Localization" Immediate Validation="@(new Func<string, Task<string?>>(ValidateBuildString))"/>
+            <MudTextField @bind-Value="inputBuild" Label="@Localizer.GetAppLocalization(nameof(Translation.BuildStringInputDialog_EnterBuildStringOrLink)).Localization" Immediate DebounceInterval="100" Validation="@(new Func<string, Task<string?>>(ValidateBuildString))"/>
         </MudFocusTrap>
     </DialogContent>
     <DialogActions>

--- a/WoWsShipBuilder.Web/Dialogs/BuildStringInputDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildStringInputDialog.razor
@@ -99,8 +99,9 @@
                     await Task.Delay(1);
                     StateHasChanged();
                     await Task.Delay(1);
-                    
-                    return null;
+
+                    inputBuildValidationResultCache = null;
+                    return inputBuildValidationResultCache;
                 }
                 
                 inputBuildValidationResultCache = $"{Localizer.SimpleAppLocalization(nameof(Translation.Validation_Incompatibility))}. {Localizer.SimpleAppLocalization(nameof(Translation.Validation_SelectedShip))}: {Localizer.GetGameLocalization(SelectedShipIndex + "_FULL").Localization} ≠ {Localizer.SimpleAppLocalization(nameof(Translation.Validation_ShipInBuild))}: {Localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}";

--- a/WoWsShipBuilder.Web/Dialogs/BuildStringInputDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildStringInputDialog.razor
@@ -1,6 +1,4 @@
-﻿@using WoWsShipBuilder.Core.Builds
-@using Microsoft.AspNetCore.WebUtilities
-@using Microsoft.Extensions.Options
+﻿@using Microsoft.Extensions.Options
 @using WoWsShipBuilder.Web.LinkShortening
 @using WoWsShipBuilder.Web.Utility
 @inject ILocalizer Localizer
@@ -47,7 +45,7 @@
     {
         MudDialog.Close(buildString.Trim());
     }
-
+    
     private async Task<string?> ValidateBuildString(string buildStr)
     {
         if (buildStr.Equals(inputBuildCache))
@@ -55,60 +53,18 @@
             // in this case there is no need to run the validation again since there were no changes to the input. Needed because validation is called also when the text field looses focus.
             return inputBuildValidationResultCache;
         }
-        
+
         inputBuildCache = buildStr;
-        buildString = string.Empty;
         
-        if (string.IsNullOrWhiteSpace(buildStr))
-        {
-            return inputBuildValidationResultCache = null;
-        }
+        var validationResult = await Validation.ValidateBuildString(buildStr, SelectedShipIndex, Localizer, LinkShorteningOptions.Value.UriPrefix);
         
-        if (buildStr.Contains(LinkShorteningOptions.Value.UriPrefix))
-        {
-            string? longUrl = await Helpers.RetrieveLongUrl(buildStr);
-            
-            if (longUrl is not null && QueryHelpers.ParseQuery(longUrl).TryGetValue("build", out var buildStrFromUrl))
-            {
-                buildStr = buildStrFromUrl.ToString(); 
-            }
-            else
-            {
-                return inputBuildValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
-            }
-        }
+        buildString = validationResult.ValidatedBuildString;
 
-        if (QueryHelpers.ParseQuery(buildStr).TryGetValue("build", out var buildStringFromUrl))
-        {
-            buildStr = buildStringFromUrl.ToString();
-        }
+        // needed to update UI
+        await Task.Delay(1);
+        StateHasChanged();
+        await Task.Delay(1);
 
-        // this is needed to avoid executing the try/catch even when we already know it is going to fail and so get a better performance
-        if (buildStr.Contains(';'))
-        {
-            try
-            {
-                var build = Build.CreateBuildFromString(buildStr);
-                if (SelectedShipIndex.Equals(build.ShipIndex))
-                {
-                    buildString = buildStr;
-                    
-                    // needed to update UI
-                    await Task.Delay(1);
-                    StateHasChanged();
-                    await Task.Delay(1);
-                    
-                    return  inputBuildValidationResultCache = null;
-                }
-                
-                return inputBuildValidationResultCache = $"{Localizer.SimpleAppLocalization(nameof(Translation.Validation_Incompatibility))}. {Localizer.SimpleAppLocalization(nameof(Translation.Validation_SelectedShip))}: {Localizer.GetGameLocalization(SelectedShipIndex + "_FULL").Localization} ≠ {Localizer.SimpleAppLocalization(nameof(Translation.Validation_ShipInBuild))}: {Localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}";
-            }
-            catch (FormatException)
-            {
-                return inputBuildValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
-            }
-        }
-        
-        return inputBuildValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
+        return inputBuildValidationResultCache = validationResult.ValidationMessage;
     }
 }

--- a/WoWsShipBuilder.Web/Dialogs/BuildStringInputDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/BuildStringInputDialog.razor
@@ -61,8 +61,7 @@
         
         if (string.IsNullOrWhiteSpace(buildStr))
         {
-            inputBuildValidationResultCache = null;
-            return inputBuildValidationResultCache;
+            return inputBuildValidationResultCache = null;
         }
         
         if (buildStr.Contains(LinkShorteningOptions.Value.UriPrefix))
@@ -75,8 +74,7 @@
             }
             else
             {
-                inputBuildValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
-                return inputBuildValidationResultCache;
+                return inputBuildValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
             }
         }
 
@@ -99,22 +97,18 @@
                     await Task.Delay(1);
                     StateHasChanged();
                     await Task.Delay(1);
-
-                    inputBuildValidationResultCache = null;
-                    return inputBuildValidationResultCache;
+                    
+                    return  inputBuildValidationResultCache = null;
                 }
                 
-                inputBuildValidationResultCache = $"{Localizer.SimpleAppLocalization(nameof(Translation.Validation_Incompatibility))}. {Localizer.SimpleAppLocalization(nameof(Translation.Validation_SelectedShip))}: {Localizer.GetGameLocalization(SelectedShipIndex + "_FULL").Localization} ≠ {Localizer.SimpleAppLocalization(nameof(Translation.Validation_ShipInBuild))}: {Localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}";
-                return inputBuildValidationResultCache;
+                return inputBuildValidationResultCache = $"{Localizer.SimpleAppLocalization(nameof(Translation.Validation_Incompatibility))}. {Localizer.SimpleAppLocalization(nameof(Translation.Validation_SelectedShip))}: {Localizer.GetGameLocalization(SelectedShipIndex + "_FULL").Localization} ≠ {Localizer.SimpleAppLocalization(nameof(Translation.Validation_ShipInBuild))}: {Localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}";
             }
             catch (FormatException)
             {
-                inputBuildValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
-                return inputBuildValidationResultCache;
+                return inputBuildValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
             }
         }
-
-        inputBuildValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
-        return inputBuildValidationResultCache;
+        
+        return inputBuildValidationResultCache = Localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild));
     }
 }

--- a/WoWsShipBuilder.Web/Dialogs/CustomAccelerationDataDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/CustomAccelerationDataDialog.razor
@@ -17,7 +17,7 @@
             <MudText>You can set custom values to be plotted in the chart. A name is required. <strong>ADVANCED USERS ONLY.</strong></MudText>
             <MudGrid>
                 <MudItem xs="12">
-                    <MudTextField @bind-Value="@name" Label="@Localizer.GetAppLocalization(nameof(Translation.ShipStats_Name)).Localization" Variant="Variant.Outlined"/>
+                    <MudTextField @bind-Value="@name" Label="@Localizer.GetAppLocalization(nameof(Translation.ShipStats_Name)).Localization" Variant="Variant.Outlined" Immediate/>
                 </MudItem>
                 <MudItem xs="6">
                    <MudSelect T="ShipClass" Variant="Variant.Outlined" @bind-Value="@selectedClass" Label="Ship Class" AnchorOrigin="Origin.BottomCenter">

--- a/WoWsShipBuilder.Web/Dialogs/CustomAccelerationDataDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/CustomAccelerationDataDialog.razor
@@ -63,7 +63,7 @@
         <MudButton OnClick="Cancel" Variant="Variant.Filled" Color="Color.Primary">
             @Localizer.GetAppLocalization(nameof(Translation.Cancel)).Localization
         </MudButton>
-        <MudButton Disabled="@string.IsNullOrWhiteSpace(name)" OnClick="ReturnShipBuildContainer" Variant="Variant.Filled" Color="Color.Primary">
+        <MudButton Disabled="EnableOkButton()" OnClick="ReturnShipBuildContainer" Variant="Variant.Filled" Color="Color.Primary">
             @Localizer.GetAppLocalization(nameof(Translation.Ok)).Localization
         </MudButton>
     </DialogActions>
@@ -164,4 +164,17 @@
         MudDialog.Close(DialogResult.Ok(container));
     }
 
+    private bool EnableOkButton()
+    {
+        return !string.IsNullOrWhiteSpace(name) &&
+               maxSpeed != 0 &&
+               enginePower != 0 &&
+               tonnage != 0 &&
+               forwardEngineUpTime != 0 &&
+               backwardEngineUpTime != 0 &&
+               forwardEngineForsag != 0 &&
+               backwardEngineForsag != 0 &&
+               forwardEngineForsagMaxSpeed != 0 &&
+               backwardEngineForsagMaxSpeed != 0;
+    }
 }

--- a/WoWsShipBuilder.Web/Dialogs/CustomAccelerationDataDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/CustomAccelerationDataDialog.razor
@@ -63,7 +63,7 @@
         <MudButton OnClick="Cancel" Variant="Variant.Filled" Color="Color.Primary">
             @Localizer.GetAppLocalization(nameof(Translation.Cancel)).Localization
         </MudButton>
-        <MudButton Disabled="EnableOkButton()" OnClick="ReturnShipBuildContainer" Variant="Variant.Filled" Color="Color.Primary">
+        <MudButton Disabled="ValidateCustomParameters()" OnClick="ReturnShipBuildContainer" Variant="Variant.Filled" Color="Color.Primary">
             @Localizer.GetAppLocalization(nameof(Translation.Ok)).Localization
         </MudButton>
     </DialogActions>
@@ -164,7 +164,7 @@
         MudDialog.Close(DialogResult.Ok(container));
     }
 
-    private bool EnableOkButton()
+    private bool ValidateCustomParameters()
     {
         return !string.IsNullOrWhiteSpace(name) &&
                maxSpeed != 0 &&

--- a/WoWsShipBuilder.Web/Dialogs/CustomAccelerationDataDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/CustomAccelerationDataDialog.razor
@@ -63,7 +63,7 @@
         <MudButton OnClick="Cancel" Variant="Variant.Filled" Color="Color.Primary">
             @Localizer.GetAppLocalization(nameof(Translation.Cancel)).Localization
         </MudButton>
-        <MudButton Disabled="ValidateCustomParameters()" OnClick="ReturnShipBuildContainer" Variant="Variant.Filled" Color="Color.Primary">
+        <MudButton Disabled="!ValidateCustomParameters()" OnClick="ReturnShipBuildContainer" Variant="Variant.Filled" Color="Color.Primary">
             @Localizer.GetAppLocalization(nameof(Translation.Ok)).Localization
         </MudButton>
     </DialogActions>
@@ -167,14 +167,14 @@
     private bool ValidateCustomParameters()
     {
         return !string.IsNullOrWhiteSpace(name) &&
-               maxSpeed != 0 &&
-               enginePower != 0 &&
-               tonnage != 0 &&
-               forwardEngineUpTime != 0 &&
-               backwardEngineUpTime != 0 &&
-               forwardEngineForsag != 0 &&
-               backwardEngineForsag != 0 &&
-               forwardEngineForsagMaxSpeed != 0 &&
-               backwardEngineForsagMaxSpeed != 0;
+               maxSpeed > 0 &&
+               enginePower > 0 &&
+               tonnage > 0 &&
+               forwardEngineUpTime > 0 &&
+               backwardEngineUpTime > 0 &&
+               forwardEngineForsag > 0 &&
+               backwardEngineForsag > 0 &&
+               forwardEngineForsagMaxSpeed > 0 &&
+               backwardEngineForsagMaxSpeed > 0;
     }
 }

--- a/WoWsShipBuilder.Web/Dialogs/FiringAngleDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/FiringAngleDialog.razor
@@ -1,5 +1,4 @@
 ﻿@using WoWsShipBuilder.Web.Data
-@using WoWsShipBuilder.Web.Services
 @implements IAsyncDisposable
 
 @inject IJSRuntime Runtime

--- a/WoWsShipBuilder.Web/Dialogs/ShipBuildContainerSelectionDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/ShipBuildContainerSelectionDialog.razor
@@ -39,7 +39,7 @@
                                                 @(Localizer.GetAppLocalization(Translation.ChartsWeb_Build).Localization + ": " + (!string.IsNullOrWhiteSpace(ship.Build?.BuildName) ? ship.Build.BuildName : ShipComparisonViewModel.DefaultBuildName))
                                             </MudText>
                                         </MudStack>
-                                        <MudIcon Icon="@Icons.Filled.Close" @onclick="@(_ => RemoveShip(ship))" Style="cursor: pointer"/>
+                                        <MudIcon Icon="@Icons.Material.Filled.Close" @onclick="@(_ => RemoveShip(ship))" Style="cursor: pointer"/>
                                     </MudStack>
                                 </MudListItem>
                             }

--- a/WoWsShipBuilder.Web/Dialogs/ShipBuildContainerSelectionDialog.razor
+++ b/WoWsShipBuilder.Web/Dialogs/ShipBuildContainerSelectionDialog.razor
@@ -101,10 +101,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        if (ShipList is null)
-        {
-            ShipList = new();
-        }
+        ShipList ??= new();
         selectedShips.CollectionChanged += SelectedShipsOnCollectionChanged;
     }
 

--- a/WoWsShipBuilder.Web/Pages/AccelerationCharts.razor
+++ b/WoWsShipBuilder.Web/Pages/AccelerationCharts.razor
@@ -27,7 +27,7 @@
 <MudExpansionPanel IsInitiallyExpanded Class="my-4 mx-4 header-border border border-solid rounded-0">
     <TitleContent>
         <div class="d-flex">
-            <MudIcon Icon="@Icons.Outlined.Info" class="mr-3"/>
+            <MudIcon Icon="@Icons.Material.Outlined.Info" class="mr-3"/>
             <MudText>@Localizer.GetAppLocalization(nameof(Translation.AccelerationChart_Explanation)).Localization</MudText>
         </div>
     </TitleContent>
@@ -240,7 +240,7 @@
         
         var result = await DialogService.Show<ShipBuildContainerSelectionDialog>("Add and remove ships", parameters, options).Result;
 
-        if (!result.Cancelled && result.Data is ShipBuildContainerSelectionDialogOutput dialogOutput)
+        if (!result.Canceled && result.Data is ShipBuildContainerSelectionDialogOutput dialogOutput)
         {
             var newShipList = dialogOutput.ShipList;
             
@@ -313,7 +313,7 @@
     {
         var result = await DialogService.Show<CustomAccelerationDataDialog>("Custom data").Result;
         
-        if (!result.Cancelled && result.Data is ShipBuildContainer shipBuildContainer)
+        if (!result.Canceled && result.Data is ShipBuildContainer shipBuildContainer)
         {
             // add the new one 
             Dictionary<int, ShipBuildContainer> shipsToAdd = new();

--- a/WoWsShipBuilder.Web/Pages/AccelerationCharts.razor
+++ b/WoWsShipBuilder.Web/Pages/AccelerationCharts.razor
@@ -8,7 +8,6 @@
 @using WoWsShipBuilder.DataStructures
 @using WoWsShipBuilder.DataStructures.Ship
 @using WoWsShipBuilder.ViewModels.Other
-@using WoWsShipBuilder.Web.Data
 @using WoWsShipBuilder.Web.Dialogs
 @using WoWsShipBuilder.Web.Services
 @using WoWsShipBuilder.Web.Utility
@@ -238,7 +237,7 @@
             { nameof(ShipBuildContainerSelectionDialog.ShipList), shipList },
         };
         
-        var result = await DialogService.Show<ShipBuildContainerSelectionDialog>("Add and remove ships", parameters, options).Result;
+        var result = await (await DialogService.ShowAsync<ShipBuildContainerSelectionDialog>("Add and remove ships", parameters, options)).Result;
 
         if (!result.Canceled && result.Data is ShipBuildContainerSelectionDialogOutput dialogOutput)
         {
@@ -311,14 +310,13 @@
     
     private async Task AddCustomShip()
     {
-        var result = await DialogService.Show<CustomAccelerationDataDialog>("Custom data").Result;
+        var result = await (await DialogService.ShowAsync<CustomAccelerationDataDialog>("Custom data")).Result;
         
         if (!result.Canceled && result.Data is ShipBuildContainer shipBuildContainer)
         {
             // add the new one 
-            Dictionary<int, ShipBuildContainer> shipsToAdd = new();
-            
-            shipsToAdd.Add(counter, shipBuildContainer);
+            Dictionary<int, ShipBuildContainer> shipsToAdd = new() { { counter, shipBuildContainer } };
+
             shipBuildCache.Add(counter, shipBuildContainer);
             counter++;
             

--- a/WoWsShipBuilder.Web/Pages/AccelerationCharts.razor
+++ b/WoWsShipBuilder.Web/Pages/AccelerationCharts.razor
@@ -18,6 +18,7 @@
 @inject IMetricsService MetricsService
 @inject IBreakpointService BreakpointService
 @inject BuildHelper BuildHelper
+@inject NavigationManager NavManager
 
 
 <PageTitle>WoWs ShipBuilder: Acceleration Charts</PageTitle>
@@ -111,8 +112,12 @@
         {
             Breakpoint = await BreakpointService.GetBreakpoint();
             await SetupChartAsync();
+            
+            NavManager.TryGetQueryString("shipIndexes", out string shipIndexesFromUrl);
 
-            var buildContainers = await BuildHelper.RetrieveBuildContainers();
+            var buildContainers = !string.IsNullOrEmpty(shipIndexesFromUrl) ? 
+                                                                shipIndexesFromUrl.Split(',').Select(x => new BuildHelper.BuildHelperContainer(x, string.Empty, null, null)) : 
+                                                                await BuildHelper.RetrieveBuildContainers();
 
             if (buildContainers is not null)
             {
@@ -129,7 +134,7 @@
                     counter++;
                 }
             }
-            
+
             await AddShipsBatchAsync(shipBuildCache);
             StateHasChanged();
         }
@@ -304,7 +309,8 @@
                 await AddShipsBatchAsync(shipsToAdd);
             }
             
-            await ChartJsInterop.BatchRemoveDataAsync(new() {AccelerationId}, guidsToRemove);
+            await ChartJsInterop.BatchRemoveDataAsync(new() { AccelerationId }, guidsToRemove);
+            UpdateUrl();
         }
     }
     
@@ -370,5 +376,11 @@
             }
         }
         return filteredList;
+    }
+    
+    private void UpdateUrl()
+    {
+        var shipsString = string.Join(",", shipBuildCache.Values.Select(x => x.Ship.Index));
+        NavManager.NavigateTo($"/acceleration-charts?shipIndexes={shipsString}");
     }
 }

--- a/WoWsShipBuilder.Web/Pages/AccelerationCharts.razor
+++ b/WoWsShipBuilder.Web/Pages/AccelerationCharts.razor
@@ -118,12 +118,12 @@
             {
                 foreach (var container in buildContainers)
                 {
-                    Build build = Build.CreateBuildFromString(container.BuildString);
-                    var shipSummary = AppData.ShipSummaryList.Single(x => x.Index.Equals(build.ShipIndex));
+                    Build? build = !string.IsNullOrWhiteSpace(container.BuildString) ? Build.CreateBuildFromString(container.BuildString) : null;
+                    var shipSummary = AppData.ShipSummaryList.Single(x => x.Index.Equals(container.ShipIndex));
                     var ship = AppData.FindShipFromSummary(shipSummary);
-                    var shipConfiguration = Helpers.GetShipConfigurationFromBuild(build.Modules, ship.ShipUpgradeInfo.ShipUpgrades);
+                    var shipConfiguration = build is null ? Helpers.GetStockShipConfiguration(ship) : Helpers.GetShipConfigurationFromBuild(build.Modules, ship.ShipUpgradeInfo.ShipUpgrades);
                     var dataContainer = ShipDataContainer.CreateFromShip(ship, shipConfiguration, container.Modifiers ?? new());
-                    var shipContainer = ShipBuildContainer.CreateNew(ship, build, container.ActivatedConsumables) with { ShipDataContainer = dataContainer };
+                    var shipContainer = ShipBuildContainer.CreateNew(ship, build, container.ActivatedConsumables) with { ShipDataContainer = dataContainer, Modifiers = container.Modifiers ?? new() };
                     
                     shipBuildCache.Add(counter, shipContainer);
                     counter++;

--- a/WoWsShipBuilder.Web/Pages/AccelerationCharts.razor
+++ b/WoWsShipBuilder.Web/Pages/AccelerationCharts.razor
@@ -115,9 +115,7 @@
             
             NavManager.TryGetQueryString("shipIndexes", out string shipIndexesFromUrl);
 
-            var buildContainers = !string.IsNullOrEmpty(shipIndexesFromUrl) ? 
-                                                                shipIndexesFromUrl.Split(',').Select(x => new BuildHelper.BuildHelperContainer(x, string.Empty, null, null)) : 
-                                                                await BuildHelper.RetrieveBuildContainers();
+            var buildContainers = await BuildHelper.RetrieveBuildContainers() ?? (!string.IsNullOrWhiteSpace(shipIndexesFromUrl) ? shipIndexesFromUrl.Split(',').Select(x => new BuildHelper.BuildHelperContainer(x, string.Empty, null, null)) : null);
 
             if (buildContainers is not null)
             {

--- a/WoWsShipBuilder.Web/Pages/Charts.razor
+++ b/WoWsShipBuilder.Web/Pages/Charts.razor
@@ -12,7 +12,6 @@
 @using WoWsShipBuilder.Core.Data
 @using WoWsShipBuilder.DataStructures.Projectile
 @using WoWsShipBuilder.ViewModels.Other
-@using System.Collections.Immutable
 
 @inject NavigationManager NavManager
 @inject ILocalizer Localizer
@@ -755,9 +754,9 @@
         return Breakpoint is Breakpoint.Xs or Breakpoint.Sm;
     }
 
-    private ImmutableDictionary<Guid, DispersionEllipse> GetDataForDispersionPlot()
+    private Dictionary<Guid, DispersionEllipse> GetDataForDispersionPlot()
     {
-        return displayedShips.Values.SelectMany(wrapper => wrapper.SelectedShells.Where(shell => shell.Value.DispPlotShipsCache is not null).Select(y => y.Value.DispPlotShipsCache!)).ToImmutableDictionary(_ => Guid.NewGuid());
+        return displayedShips.Values.SelectMany(wrapper => wrapper.SelectedShells.Where(shell => shell.Value.DispPlotShipsCache is not null).Select(y => y.Value.DispPlotShipsCache!)).ToDictionary(_ => Guid.NewGuid());
     }
 
     private static string GenerateJsShipId(Guid id, string shellIndex)

--- a/WoWsShipBuilder.Web/Pages/Charts.razor
+++ b/WoWsShipBuilder.Web/Pages/Charts.razor
@@ -320,7 +320,7 @@
             if (shipIndexesFromUrl.Any())
             {
                 var buildContainers = await BuildHelper.RetrieveBuildContainers();
-                if (shellIndexFromUrl.Any() && buildContainers is not null)
+                if (buildContainers is not null)
                 {
                     List<ChartsDataWrapper> shipsToAdd = new();
                     foreach (var container in buildContainers)

--- a/WoWsShipBuilder.Web/Pages/Charts.razor
+++ b/WoWsShipBuilder.Web/Pages/Charts.razor
@@ -681,7 +681,7 @@
         {
             ["InputData"] = displayedShips.Values.ToList(),
         };
-        var dialog = DialogService.Show<ShipAndShellSelectionDialog>("ShipAndShellSelectionDialog", parameters, options);
+        var dialog = await DialogService.ShowAsync<ShipAndShellSelectionDialog>("ShipAndShellSelectionDialog", parameters, options);
         return await dialog.Result;
     }
 

--- a/WoWsShipBuilder.Web/Pages/Charts.razor
+++ b/WoWsShipBuilder.Web/Pages/Charts.razor
@@ -255,7 +255,7 @@
     </MudTabPanel>
 </MudTabs>
 <MudScrollToTop TopOffset="100" Style="z-index:2001">
-    <MudFab Color="Color.Info" StartIcon="@Icons.Filled.KeyboardDoubleArrowUp"/>
+    <MudFab Color="Color.Info" StartIcon="@Icons.Material.Filled.KeyboardDoubleArrowUp"/>
 </MudScrollToTop>
 <BuildConfigurationDialogHelper @ref="buildConfigurationHelper" MaxWidth="MaxWidth.Large" FullWidth NoHeader />
 
@@ -607,7 +607,7 @@
     {
         SetProcessing(true);
         var selectedShipList = await GetSelectedShipsAsync();
-        if (selectedShipList is null || selectedShipList.Cancelled)
+        if (selectedShipList is null || selectedShipList.Canceled)
         {
             SetProcessing(false);
             return;

--- a/WoWsShipBuilder.Web/Pages/Charts.razor
+++ b/WoWsShipBuilder.Web/Pages/Charts.razor
@@ -302,7 +302,7 @@
         {
             shellIndexFromUrl = shellIndex;
         }
-        if (NavManager.TryGetQueryString("shipIndex", out string shipIndex))
+        if (NavManager.TryGetQueryString("shipIndexes", out string shipIndex))
         {
             shipIndexesFromUrl = shipIndex.Split(',');
         }

--- a/WoWsShipBuilder.Web/Pages/Charts.razor
+++ b/WoWsShipBuilder.Web/Pages/Charts.razor
@@ -302,7 +302,7 @@
         {
             shellIndexFromUrl = shellIndex;
         }
-        if (NavManager.TryGetQueryString("shipIndexes", out string shipIndex))
+        if (NavManager.TryGetQueryString("shipIndex", out string shipIndex))
         {
             shipIndexesFromUrl = shipIndex.Split(',');
         }
@@ -341,7 +341,7 @@
                         }
                         
                         var dataContainer = ShipDataContainer.CreateFromShip(ship, shipConfiguration, container.Modifiers ?? new());
-                        ChartsDataWrapper wrapper = new(ShipBuildContainer.CreateNew(ship, build, container.ActivatedConsumables) with { ShipDataContainer = dataContainer, Modifiers = container.Modifiers} , new());
+                        ChartsDataWrapper wrapper = new(ShipBuildContainer.CreateNew(ship, build, container.ActivatedConsumables) with { ShipDataContainer = dataContainer, Modifiers = container.Modifiers } , new());
                         
                         if (shellIndexFromUrl.Any())
                         {

--- a/WoWsShipBuilder.Web/Pages/ShipComparison.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipComparison.razor
@@ -332,7 +332,7 @@
     <BuildConfigurationDialogHelper @ref="buildConfigurationHelper" MaxWidth="MaxWidth.Large" DisableBackdropClick="true" FullWidth NoHeader/>
 
     <MudScrollToTop TopOffset="100" Style="z-index:2001" Visible="@(!isDialogOpen)">
-        <MudFab Color="Color.Info" StartIcon="@Icons.Filled.KeyboardDoubleArrowUp"/>
+        <MudFab Color="Color.Info" StartIcon="@Icons.Material.Filled.KeyboardDoubleArrowUp"/>
     </MudScrollToTop>
 }
 
@@ -436,7 +436,7 @@
 
     private string IsShipPinnedIcon(ShipComparisonDataWrapper wrapper)
     {
-        return ShipComparisonViewModel.ContainsWrapper(wrapper, ViewModel!.PinnedShipList) ? Icons.Filled.PushPin : Icons.Outlined.PushPin;
+        return ShipComparisonViewModel.ContainsWrapper(wrapper, ViewModel!.PinnedShipList) ? Icons.Material.Filled.PushPin : Icons.Material.Outlined.PushPin;
     }
 
     private Color IsShipSelectedColor(ShipComparisonDataWrapper wrapper)
@@ -446,7 +446,7 @@
 
     private string IsShipSelectedIcon(ShipComparisonDataWrapper wrapper)
     {
-        return ShipComparisonViewModel.ContainsWrapper(wrapper, ViewModel!.SelectedShipList) ? Icons.Filled.CheckBox : Icons.Filled.CheckBoxOutlineBlank;
+        return ShipComparisonViewModel.ContainsWrapper(wrapper, ViewModel!.SelectedShipList) ? Icons.Material.Filled.CheckBox : Icons.Material.Filled.CheckBoxOutlineBlank;
     }
 
     private async Task EditBuilds(ShipComparisonDataWrapper? wrapper = null)

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -19,7 +19,7 @@
             @foreach (var container in shipContainers)
             {
                 <MudTabPanel Style="@(GetStyle(container.Id))" Text="@Localizer.GetGameLocalization(container.ShipIndex + "_FULL").Localization" Tag="@container.Id" ID="@container.Id" @key="@indexIdMapper[container.Id]">
-                    <ShipStatsContainer @ref="@shipStatsContainerCache[container.Id]" CachedViewModel="@shipStatsContainerCache[container.Id]?.ViewModel" CurrentTabId="container.Id" ShipIndex="@container.ShipIndex" OnShipChanged="@OnShipIndexChanged" BuildString="@container.BuildString"/>
+                    <ShipStatsContainer @ref="@shipStatsContainerCache[container.Id]" CachedInstance="@shipStatsContainerCache[container.Id]" CurrentTabId="container.Id" ShipIndex="@container.ShipIndex" OnShipChanged="@OnShipIndexChanged" BuildString="@container.BuildString"/>
                 </MudTabPanel>
             }
         </ChildContent>

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -14,12 +14,12 @@
 
 <MudBreakpointProvider>
     @* HideSlider is set to true because of an issue in MudBlazor. see https://github.com/MudBlazor/MudBlazor/issues/4742*@
-    <MudDynamicTabs Color="Color.Primary" Position="Position.Top" HideSlider KeepPanelsAlive CloseTab="@RemoveTab" @ref="mudTabs" Elevation="2" PanelClass="px-md-6 py-6" Outlined Border Class="pt-3">
+    <MudDynamicTabs Color="Color.Primary" Position="Position.Top" HideSlider CloseTab="@RemoveTab" @ref="mudTabs" Elevation="2" PanelClass="px-md-6 py-6" Outlined Border Class="pt-3">
         <ChildContent>
             @foreach (var container in shipContainers)
             {
                 <MudTabPanel Style="@(GetStyle(container.Id))" Text="@Localizer.GetGameLocalization(container.ShipIndex + "_FULL").Localization" Tag="@container.Id" ID="@container.Id" @key="@indexIdMapper[container.Id]">
-                    <ShipStatsContainer @ref="shipStatsContainerCache[container.Id]" CurrentTabId="container.Id" ShipIndex="@container.ShipIndex" OnShipChanged="@OnShipIndexChanged" BuildString="@container.BuildString"/>
+                    <ShipStatsContainer @ref="shipStatsContainerCache[container.Id]" CachedViewModel="@shipStatsContainerCache[container.Id]?.ViewModel" CurrentTabId="container.Id" ShipIndex="@container.ShipIndex" OnShipChanged="@OnShipIndexChanged" BuildString="@container.BuildString"/>
                 </MudTabPanel>
             }
         </ChildContent>
@@ -37,7 +37,7 @@
     </MudDynamicTabs>
 </MudBreakpointProvider>
 <MudScrollToTop TopOffset="100" Style="z-index:2001">
-     <MudFab Color="Color.Info" StartIcon="@Icons.Filled.KeyboardDoubleArrowUp"/>
+     <MudFab Color="Color.Info" StartIcon="@Icons.Material.Filled.KeyboardDoubleArrowUp"/>
 </MudScrollToTop>
 
 @code {
@@ -156,7 +156,7 @@
             DisableBackdropClick = false,
         };
         var result = await DialogService.Show<ShipSelectionDialog>("Add ships", options).Result;
-        if (!result.Cancelled && result.Data is List<ShipSelector.ShipSelectorContainer> {Count: > 0 } newShips)
+        if (!result.Canceled && result.Data is List<ShipSelector.ShipSelectorContainer> {Count: > 0 } newShips)
         {
             AddNewIndexes(new() { newShips.First().ShipIndex }, new() { new(newShips.First().ShipIndex, newShips.First().BuildString ?? string.Empty, null, null) });
             selectedTabId = shipContainers.Last().Id;

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -27,10 +27,10 @@
             <MudStack Row>
                 <MudDivider Vertical/>
                 <MudTooltip Text="@Localizer.GetAppLocalization(Translation.DispersionGraphWindow_AddShip).Localization" Delay="350">
-                    <MudIconButton Icon="@Icons.Material.Filled.Add" OnClick="@OpenAddDialogAsync"/>
+                    <MudIconButton Icon="@Icons.Material.Filled.Add" OnClick="@OpenAddDialogAsync" Color="Color.Secondary"/>
                 </MudTooltip>
                 <MudTooltip Text="@Localizer.GetAppLocalization(Translation.ShipStats_ShowInCharts).Localization" Delay="350">
-                    <MudIconButton Icon="@Icons.Material.Filled.BarChart" OnClick="@SendAllShipsToCharts"/>
+                    <MudIconButton Icon="@Icons.Material.Filled.BarChart" OnClick="@SendAllShipsToCharts" Color="Color.Secondary"/>
                 </MudTooltip>
             </MudStack>
         </Header>
@@ -109,10 +109,8 @@
         }
         else
         {
-            var newId = Guid.NewGuid();
-            shipContainers.Add(new(newId, newShipIndex, null));
-            indexIdMapper[newId] = (idCount++).ToString();
-            selectedTabId = newId;
+            AddNewIndexes(new(){ newShipIndex }, null);
+            selectedTabId = indexIdMapper.Last().Key;
         }
         UpdateUrl();
         updateTab = true;
@@ -159,7 +157,7 @@
         if (!result.Canceled && result.Data is List<ShipSelector.ShipSelectorContainer> {Count: > 0 } newShips)
         {
             AddNewIndexes(new() { newShips.First().ShipIndex }, new() { new(newShips.First().ShipIndex, newShips.First().BuildString ?? string.Empty, null, null) });
-            selectedTabId = shipContainers.Last().Id;
+            selectedTabId = indexIdMapper.Last().Key;
             AddNewIndexes(newShips.Skip(1).Select(x => x.ShipIndex).ToList(), newShips.Skip(1).Select(x => new BuildHelper.BuildHelperContainer(x.ShipIndex, x.BuildString ?? string.Empty, null, null)).ToList());
             updateTab = true;
 

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -212,7 +212,8 @@
                 }
                 else
                 {
-                    var viewModel = await shipStatsContainerCache.First().Value!.GetShipViewModel(container.ShipIndex, container.BuildString);
+                    var tmpSc= shipStatsContainerCache.First().Value ?? new ShipStatsContainer();
+                    var viewModel = await tmpSc.GetShipViewModel(container.ShipIndex, container.BuildString);
                     
                     List<(string, float)>? modifiers = viewModel?.UpgradePanelViewModel.GetModifierList();
                     modifiers?.AddRange(viewModel?.ConsumableViewModel.GetModifiersList() ?? new List<(string, float)>());

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -30,7 +30,7 @@
                     <MudIconButton Icon="@Icons.Material.Filled.Add" OnClick="@OpenAddDialogAsync"/>
                 </MudTooltip>
                 <MudTooltip Text="@Localizer.GetAppLocalization(Translation.ShipStats_ShowInCharts).Localization" Delay="350">
-                    <MudIconButton Icon="@Icons.Material.Filled.BarChart" OnClick="@SendAllToCharts"/>
+                    <MudIconButton Icon="@Icons.Material.Filled.BarChart" OnClick="@SendAllShipsToCharts"/>
                 </MudTooltip>
             </MudStack>
         </Header>
@@ -46,7 +46,7 @@
 
     private readonly List<ShipSelector.ShipSelectorContainer> shipContainers = new();
 
-    private readonly Dictionary<Guid, ShipStatsContainer> shipStatsContainerCache = new();
+    private readonly Dictionary<Guid, ShipStatsContainer?> shipStatsContainerCache = new();
 
     private string shipIndexesFromUrl = default!;
 
@@ -155,7 +155,7 @@
             CloseOnEscapeKey = true,
             DisableBackdropClick = false,
         };
-        var result = await DialogService.Show<ShipSelectionDialog>("Add ships", options).Result;
+        var result = await (await DialogService.ShowAsync<ShipSelectionDialog>("Add ships", options)).Result;
         if (!result.Canceled && result.Data is List<ShipSelector.ShipSelectorContainer> {Count: > 0 } newShips)
         {
             AddNewIndexes(new() { newShips.First().ShipIndex }, new() { new(newShips.First().ShipIndex, newShips.First().BuildString ?? string.Empty, null, null) });
@@ -195,14 +195,37 @@
         shipContainers.AddRange(newShips);
     }
 
-    private async Task SendAllToCharts()
+    private async Task SendAllShipsToCharts()
     {
         List<BuildHelper.BuildHelperContainer> buildContainers = new();
         List<string> shipIndexes = new();
-        foreach (var shipStatsContainer in shipStatsContainerCache)
+        foreach (var container in shipContainers)
         {
-            buildContainers.Add(shipStatsContainer.Value.GetBuildContainer());
-            shipIndexes.Add(shipStatsContainer.Value.ShipIndex);
+            var shipStatsContainer = shipStatsContainerCache[container.Id];
+            if (shipStatsContainer is not null)
+            {
+                buildContainers.Add(shipStatsContainer.GetBuildHelperContainer());
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(container.BuildString))
+                {
+                    buildContainers.Add(new(container.ShipIndex, string.Empty, null, null));
+                }
+                else
+                {
+                    var viewModel = await shipStatsContainerCache.First().Value!.LoadShipVm(container.ShipIndex, container.BuildString);
+                    
+                    List<(string, float)>? modifiers = viewModel?.UpgradePanelViewModel.GetModifierList();
+                    modifiers?.AddRange(viewModel?.ConsumableViewModel.GetModifiersList() ?? new List<(string, float)>());
+                    modifiers?.AddRange(viewModel?.CaptainSkillSelectorViewModel?.GetModifiersList() ?? new List<(string, float)>());
+                    modifiers?.AddRange(viewModel?.SignalSelectorViewModel?.GetModifierList() ?? new List<(string, float)>());
+                    
+                    buildContainers.Add(new(container.ShipIndex, container.BuildString, modifiers, viewModel?.ConsumableViewModel.ActivatedSlots));   
+                }
+            }
+            
+            shipIndexes.Add(container.ShipIndex);   
         }
         
         await BuildHelper.StoreBuildContainers(buildContainers);

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -31,8 +31,8 @@
                     <MudIconButton Icon="@Icons.Material.Filled.Add" OnClick="@OpenAddDialogAsync" Color="Color.Secondary"/>
                 </MudTooltip>
                 <MudTooltip Text="@Localizer.GetAppLocalization(Translation.ShipStats_ShowInBallisticCharts).Localization" Arrow Delay="350">
-                    <MudIconButton OnClick="@OpenBallisticCharts" Color="Color.Secondary">
-                        <MudIcon Icon="@DispersionAndBallisticChartsPath" ViewBox="-4 -4 24 24"/>
+                    <MudIconButton OnClick="@OpenBallisticCharts" Color="Color.Secondary" Style="width: 48px; height: 48px">
+                        <MudIcon Icon="@DispersionAndBallisticChartsPath" ViewBox="-4 -7 24 24"/>
                     </MudIconButton>
                 </MudTooltip>
                 <MudTooltip Text="@Localizer.GetAppLocalization(Translation.ShipStats_ShowInAccelerationCharts).Localization" Arrow Delay="350">

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -31,7 +31,9 @@
                     <MudIconButton Icon="@Icons.Material.Filled.Add" OnClick="@OpenAddDialogAsync" Color="Color.Secondary"/>
                 </MudTooltip>
                 <MudTooltip Text="@Localizer.GetAppLocalization(Translation.ShipStats_ShowInBallisticCharts).Localization" Arrow Delay="350">
-                    <MudIconButton Icon="@Icons.Material.Filled.SsidChart" OnClick="@OpenBallisticCharts" Color="Color.Secondary"/>
+                    <MudIconButton OnClick="@OpenBallisticCharts" Color="Color.Secondary">
+                        <MudIcon Icon="@DispersionAndBallisticChartsPath" ViewBox="-4 -4 24 24"/>
+                    </MudIconButton>
                 </MudTooltip>
                 <MudTooltip Text="@Localizer.GetAppLocalization(Translation.ShipStats_ShowInAccelerationCharts).Localization" Arrow Delay="350">
                     <MudIconButton Icon="@Icons.Material.Filled.Speed" OnClick="@OpenAccelerationCharts" Color="Color.Secondary"/>
@@ -45,6 +47,8 @@
 </MudScrollToTop>
 
 @code {
+    
+    private const string DispersionAndBallisticChartsPath = @"<path d=""M1.5 1.75V13.5h13.75a.75.75 0 0 1 0 1.5H.75a.75.75 0 0 1-.75-.75V1.75a.75.75 0 0 1 1.5 0Zm14.28 2.53-5.25 5.25a.75.75 0 0 1-1.06 0L7 7.06 4.28 9.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.25-3.25a.75.75 0 0 1 1.06 0L10 7.94l4.72-4.72a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"" stroke-width="".053058""/>";
 
     private MudTabs mudTabs = default!;
 

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -20,7 +20,7 @@
             @foreach (var container in shipContainers)
             {
                 <MudTabPanel Style="@(GetStyle(container.Id))" Text="@Localizer.GetGameLocalization(container.ShipIndex + "_FULL").Localization" Tag="@container.Id" ID="@container.Id" @key="@container.Id">
-                    <ShipStatsContainer CacheService="@cacheService" CurrentTabId="container.Id" ShipIndex="@container.ShipIndex" OnShipChanged="@OnShipIndexChanged" BuildString="@container.BuildString"/>
+                    <ShipStatsContainer Cache="@cache" CurrentTabId="container.Id" ShipIndex="@container.ShipIndex" OnShipChanged="@OnShipIndexChanged" BuildString="@container.BuildString"/>
                 </MudTabPanel>
             }
         </ChildContent>
@@ -54,7 +54,7 @@
 
     private readonly List<ShipSelector.ShipSelectorContainer> shipContainers = new();
 
-    private readonly VmCacheService cacheService = new();
+    private readonly VmCache cache = new();
 
     private string shipIndexesFromUrl = default!;
 
@@ -128,7 +128,7 @@
         var ship = shipContainers.First(x => x.Id.Equals(id));
         int index = shipContainers.IndexOf(ship);
         shipContainers.Remove(ship);
-        cacheService.RemoveEntry(id);
+        cache.RemoveEntry(id);
 
         if (mudTabs.ActivePanel.ID.Equals(panel.ID))
         {
@@ -182,7 +182,7 @@
         List<string> shipIndexes = new();
         foreach (var container in shipContainers)
         {
-            var vmCacheEntry = cacheService.GetOrDefault(container.Id);
+            var vmCacheEntry = cache.GetOrDefault(container.Id);
             if (vmCacheEntry is not null)
             {
                 buildContainers.Add(ShipStatsContainer.GetBuildHelperContainer(vmCacheEntry));

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -19,8 +19,8 @@
         <ChildContent>
             @foreach (var container in shipContainers)
             {
-                <MudTabPanel Style="@(GetStyle(container.Id))" Text="@Localizer.GetGameLocalization(container.ShipIndex + "_FULL").Localization" Tag="@container.Id" ID="@container.Id" @key="@indexIdMapper[container.Id]">
-                    <ShipStatsContainer @ref="@shipStatsContainerCache[container.Id]" CachedInstance="@shipStatsContainerCache[container.Id]" CurrentTabId="container.Id" ShipIndex="@container.ShipIndex" OnShipChanged="@OnShipIndexChanged" BuildString="@container.BuildString"/>
+                <MudTabPanel Style="@(GetStyle(container.Id))" Text="@Localizer.GetGameLocalization(container.ShipIndex + "_FULL").Localization" Tag="@container.Id" ID="@container.Id" @key="@container.Id">
+                    <ShipStatsContainer CacheService="@cacheService" CurrentTabId="container.Id" ShipIndex="@container.ShipIndex" OnShipChanged="@OnShipIndexChanged" BuildString="@container.BuildString"/>
                 </MudTabPanel>
             }
         </ChildContent>
@@ -54,7 +54,7 @@
 
     private readonly List<ShipSelector.ShipSelectorContainer> shipContainers = new();
 
-    private readonly Dictionary<Guid, ShipStatsContainer?> shipStatsContainerCache = new();
+    private readonly VmCacheService cacheService = new();
 
     private string shipIndexesFromUrl = default!;
 
@@ -63,10 +63,6 @@
     private bool updateTab;
 
     private Guid selectedTabId;
-
-    private int idCount;
-
-    private readonly Dictionary<Guid, string> indexIdMapper = new();
 
     protected override async Task OnInitializedAsync()
     {
@@ -89,7 +85,8 @@
             {
                 buildList = null;
             }
-var indexes = shipIndexesFromUrl.Split(",").ToList();
+            
+            var indexes = shipIndexesFromUrl.Split(",").ToList();
             AddNewIndexes(indexes, buildList);
         }
         UpdateUrl();
@@ -117,7 +114,7 @@ var indexes = shipIndexesFromUrl.Split(",").ToList();
         else
         {
             AddNewIndexes(new() { newShipIndex }, null);
-            selectedTabId = indexIdMapper.Last().Key;
+            selectedTabId = shipContainers.Last().Id;
         }
         UpdateUrl();
         updateTab = true;
@@ -131,15 +128,14 @@ var indexes = shipIndexesFromUrl.Split(",").ToList();
         var ship = shipContainers.First(x => x.Id.Equals(id));
         int index = shipContainers.IndexOf(ship);
         shipContainers.Remove(ship);
-        indexIdMapper.Remove(id);
-        shipStatsContainerCache.Remove(id);
+        cacheService.RemoveEntry(id);
 
         if (mudTabs.ActivePanel.ID.Equals(panel.ID))
         {
-    // If shipIndexes contains more element than index (meaning, index is not out of bound for the shipIndexes list), then we select the ship at the same index.
-    // We do it with the ID because using the index makes the tab appear as blank ("display: none" in the style).
-    // If the index is out of bound, we check if the shipIndexes has any element, in which case we take the last element of the list, since it means we removed the old last element.
-    // Finally, if the list is empty, we check if the new ship tab is present. If it is, we select that one, otherwise we do nothing.
+            // If shipIndexes contains more element than index (meaning, index is not out of bound for the shipIndexes list), then we select the ship at the same index.
+            // We do it with the ID because using the index makes the tab appear as blank ("display: none" in the style).
+            // If the index is out of bound, we check if the shipIndexes has any element, in which case we take the last element of the list, since it means we removed the old last element.
+            // Finally, if the list is empty, we check if the new ship tab is present. If it is, we select that one, otherwise we do nothing.
             if (shipContainers.Count > index && index != -1)
             {
                 mudTabs.ActivatePanel(shipContainers[index].Id);
@@ -161,10 +157,10 @@ var indexes = shipIndexesFromUrl.Split(",").ToList();
             DisableBackdropClick = false,
         };
         var result = await (await DialogService.ShowAsync<ShipSelectionDialog>("Add ships", options)).Result;
-        if (!result.Canceled && result.Data is List<ShipSelector.ShipSelectorContainer> {Count: > 0 } newShips)
+        if (!result.Canceled && result.Data is List<ShipSelector.ShipSelectorContainer> { Count: > 0 } newShips)
         {
             AddNewIndexes(new() { newShips.First().ShipIndex }, new() { new(newShips.First().ShipIndex, newShips.First().BuildString ?? string.Empty, null, null) });
-            selectedTabId = indexIdMapper.Last().Key;
+            selectedTabId = shipContainers.Last().Id;
             AddNewIndexes(newShips.Skip(1).Select(x => x.ShipIndex).ToList(), newShips.Skip(1).Select(x => new BuildHelper.BuildHelperContainer(x.ShipIndex, x.BuildString ?? string.Empty, null, null)).ToList());
             updateTab = true;
 
@@ -176,27 +172,7 @@ var indexes = shipIndexesFromUrl.Split(",").ToList();
     private void AddNewIndexes(List<string> indexList, List<BuildHelper.BuildHelperContainer>? buildContainers)
     {
         List<ShipSelector.ShipSelectorContainer> newShips = new();
-        if (buildContainers is null)
-        {
-            foreach (var index in indexList)
-            {
-                var newShip = new ShipSelector.ShipSelectorContainer(Guid.NewGuid(), index, null);
-                newShips.Add(newShip);
-                indexIdMapper[newShip.Id] = (idCount++).ToString();
-                shipStatsContainerCache.Add(newShip.Id, default!);
-            }
-        }
-        else
-        {
-            foreach (var container in buildContainers)
-            {
-                var newShip = new ShipSelector.ShipSelectorContainer(Guid.NewGuid(), container.ShipIndex, container.BuildString);
-                newShips.Add(newShip);
-                indexIdMapper[newShip.Id] = (idCount++).ToString();
-                shipStatsContainerCache.Add(newShip.Id, default!);
-            }
-        }
-
+        newShips.AddRange(buildContainers is null ? indexList.Select(index => new ShipSelector.ShipSelectorContainer(Guid.NewGuid(), index, null)) : buildContainers.Select(container => new ShipSelector.ShipSelectorContainer(Guid.NewGuid(), container.ShipIndex, container.BuildString)));
         shipContainers.AddRange(newShips);
     }
 
@@ -206,10 +182,10 @@ var indexes = shipIndexesFromUrl.Split(",").ToList();
         List<string> shipIndexes = new();
         foreach (var container in shipContainers)
         {
-            var shipStatsContainer = shipStatsContainerCache[container.Id];
-            if (shipStatsContainer is not null)
+            var vmCacheEntry = cacheService.GetOrDefault(container.Id);
+            if (vmCacheEntry is not null)
             {
-                buildContainers.Add(shipStatsContainer.GetBuildHelperContainer());
+                buildContainers.Add(ShipStatsContainer.GetBuildHelperContainer(vmCacheEntry));
             }
             else
             {

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -2,6 +2,7 @@
 
 @using WoWsShipBuilder.Web.Utility
 @using DynamicData
+@using WoWsShipBuilder.Core.Builds
 @using WoWsShipBuilder.Web.Dialogs
 @using WoWsShipBuilder.Web.Services
 
@@ -40,7 +41,7 @@
     </MudDynamicTabs>
 </MudBreakpointProvider>
 <MudScrollToTop TopOffset="100" Style="z-index:2001">
-     <MudFab Color="Color.Info" StartIcon="@Icons.Material.Filled.KeyboardDoubleArrowUp"/>
+    <MudFab Color="Color.Info" StartIcon="@Icons.Material.Filled.KeyboardDoubleArrowUp"/>
 </MudScrollToTop>
 
 @code {
@@ -84,8 +85,7 @@
             {
                 buildList = null;
             }
-            
-            var indexes = shipIndexesFromUrl.Split(",").ToList();
+var indexes = shipIndexesFromUrl.Split(",").ToList();
             AddNewIndexes(indexes, buildList);
         }
         UpdateUrl();
@@ -112,7 +112,7 @@
         }
         else
         {
-            AddNewIndexes(new(){ newShipIndex }, null);
+            AddNewIndexes(new() { newShipIndex }, null);
             selectedTabId = indexIdMapper.Last().Key;
         }
         UpdateUrl();
@@ -123,7 +123,7 @@
 
     private void RemoveTab(MudTabPanel panel)
     {
-        var id = (Guid)panel.Tag;
+        var id = (Guid) panel.Tag;
         var ship = shipContainers.First(x => x.Id.Equals(id));
         int index = shipContainers.IndexOf(ship);
         shipContainers.Remove(ship);
@@ -132,10 +132,10 @@
 
         if (mudTabs.ActivePanel.ID.Equals(panel.ID))
         {
-            // If shipIndexes contains more element than index (meaning, index is not out of bound for the shipIndexes list), then we select the ship at the same index.
-            // We do it with the ID because using the index makes the tab appear as blank ("display: none" in the style).
-            // If the index is out of bound, we check if the shipIndexes has any element, in which case we take the last element of the list, since it means we removed the old last element.
-            // Finally, if the list is empty, we check if the new ship tab is present. If it is, we select that one, otherwise we do nothing.
+    // If shipIndexes contains more element than index (meaning, index is not out of bound for the shipIndexes list), then we select the ship at the same index.
+    // We do it with the ID because using the index makes the tab appear as blank ("display: none" in the style).
+    // If the index is out of bound, we check if the shipIndexes has any element, in which case we take the last element of the list, since it means we removed the old last element.
+    // Finally, if the list is empty, we check if the new ship tab is present. If it is, we select that one, otherwise we do nothing.
             if (shipContainers.Count > index && index != -1)
             {
                 mudTabs.ActivatePanel(shipContainers[index].Id);
@@ -192,7 +192,7 @@
                 shipStatsContainerCache.Add(newShip.Id, default!);
             }
         }
-        
+
         shipContainers.AddRange(newShips);
     }
 
@@ -215,21 +215,20 @@
                 }
                 else
                 {
-                    var tmpSc= shipStatsContainerCache.Values.FirstOrDefault(x => x is not null) ?? new ShipStatsContainer();
-                    var viewModel = await tmpSc.GetShipViewModel(container.ShipIndex, container.BuildString);
-                    
-                    List<(string, float)>? modifiers = viewModel?.UpgradePanelViewModel.GetModifierList();
-                    modifiers?.AddRange(viewModel?.ConsumableViewModel.GetModifiersList() ?? new List<(string, float)>());
-                    modifiers?.AddRange(viewModel?.CaptainSkillSelectorViewModel?.GetModifiersList() ?? new List<(string, float)>());
-                    modifiers?.AddRange(viewModel?.SignalSelectorViewModel?.GetModifierList() ?? new List<(string, float)>());
-                    
-                    buildContainers.Add(new(container.ShipIndex, container.BuildString, modifiers, viewModel?.ConsumableViewModel.ActivatedSlots));   
+                    var viewModel = await ShipStatsContainer.CreateViewModel(container.ShipIndex, Build.CreateBuildFromString(container.BuildString), Localizer);
+
+                    List<(string, float)> modifiers = viewModel.UpgradePanelViewModel.GetModifierList();
+                    modifiers.AddRange(viewModel.ConsumableViewModel.GetModifiersList());
+                    modifiers.AddRange(viewModel.CaptainSkillSelectorViewModel?.GetModifiersList() ?? new List<(string, float)>());
+                    modifiers.AddRange(viewModel.SignalSelectorViewModel?.GetModifierList() ?? new List<(string, float)>());
+
+                    buildContainers.Add(new(container.ShipIndex, container.BuildString, modifiers, viewModel.ConsumableViewModel.ActivatedSlots));
                 }
             }
-            
-            shipIndexes.Add(container.ShipIndex);   
+
+            shipIndexes.Add(container.ShipIndex);
         }
-        
+
         await BuildHelper.StoreBuildContainers(buildContainers);
         return shipIndexes;
     }
@@ -239,7 +238,7 @@
         var shipIndexes = await StoreBuildsForCharts();
         NavManager.NavigateTo($"/charts?shipIndex={string.Join(",", shipIndexes)}");
     }
-    
+
     private async Task OpenAccelerationCharts()
     {
         var shipIndexes = await StoreBuildsForCharts();

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -214,7 +214,7 @@
                 }
                 else
                 {
-                    var viewModel = await shipStatsContainerCache.First().Value!.LoadShipVm(container.ShipIndex, container.BuildString);
+                    var viewModel = await shipStatsContainerCache.First().Value!.GetShipViewModel(container.ShipIndex, container.BuildString);
                     
                     List<(string, float)>? modifiers = viewModel?.UpgradePanelViewModel.GetModifierList();
                     modifiers?.AddRange(viewModel?.ConsumableViewModel.GetModifiersList() ?? new List<(string, float)>());

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -19,7 +19,7 @@
             @foreach (var container in shipContainers)
             {
                 <MudTabPanel Style="@(GetStyle(container.Id))" Text="@Localizer.GetGameLocalization(container.ShipIndex + "_FULL").Localization" Tag="@container.Id" ID="@container.Id" @key="@indexIdMapper[container.Id]">
-                    <ShipStatsContainer @ref="shipStatsContainerCache[container.Id]" CachedViewModel="@shipStatsContainerCache[container.Id]?.ViewModel" CurrentTabId="container.Id" ShipIndex="@container.ShipIndex" OnShipChanged="@OnShipIndexChanged" BuildString="@container.BuildString"/>
+                    <ShipStatsContainer @ref="@shipStatsContainerCache[container.Id]" CachedViewModel="@shipStatsContainerCache[container.Id]?.ViewModel" CurrentTabId="container.Id" ShipIndex="@container.ShipIndex" OnShipChanged="@OnShipIndexChanged" BuildString="@container.BuildString"/>
                 </MudTabPanel>
             }
         </ChildContent>

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -26,11 +26,14 @@
         <Header>
             <MudStack Row>
                 <MudDivider Vertical/>
-                <MudTooltip Text="@Localizer.GetAppLocalization(Translation.DispersionGraphWindow_AddShip).Localization" Delay="350">
+                <MudTooltip Text="@Localizer.GetAppLocalization(Translation.DispersionGraphWindow_AddShip).Localization" Arrow Delay="350">
                     <MudIconButton Icon="@Icons.Material.Filled.Add" OnClick="@OpenAddDialogAsync" Color="Color.Secondary"/>
                 </MudTooltip>
-                <MudTooltip Text="@Localizer.GetAppLocalization(Translation.ShipStats_ShowInCharts).Localization" Delay="350">
-                    <MudIconButton Icon="@Icons.Material.Filled.BarChart" OnClick="@SendAllShipsToCharts" Color="Color.Secondary"/>
+                <MudTooltip Text="@Localizer.GetAppLocalization(Translation.ShipStats_ShowInBallisticCharts).Localization" Arrow Delay="350">
+                    <MudIconButton Icon="@Icons.Material.Filled.SsidChart" OnClick="@OpenBallisticCharts" Color="Color.Secondary"/>
+                </MudTooltip>
+                <MudTooltip Text="@Localizer.GetAppLocalization(Translation.ShipStats_ShowInAccelerationCharts).Localization" Arrow Delay="350">
+                    <MudIconButton Icon="@Icons.Material.Filled.Speed" OnClick="@OpenAccelerationCharts" Color="Color.Secondary"/>
                 </MudTooltip>
             </MudStack>
         </Header>
@@ -193,7 +196,7 @@
         shipContainers.AddRange(newShips);
     }
 
-    private async Task SendAllShipsToCharts()
+    private async Task<List<string>> StoreBuildsForCharts()
     {
         List<BuildHelper.BuildHelperContainer> buildContainers = new();
         List<string> shipIndexes = new();
@@ -228,7 +231,19 @@
         }
         
         await BuildHelper.StoreBuildContainers(buildContainers);
+        return shipIndexes;
+    }
+
+    private async Task OpenBallisticCharts()
+    {
+        var shipIndexes = await StoreBuildsForCharts();
         NavManager.NavigateTo($"/charts?shipIndex={string.Join(",", shipIndexes)}");
+    }
+    
+    private async Task OpenAccelerationCharts()
+    {
+        var shipIndexes = await StoreBuildsForCharts();
+        NavManager.NavigateTo($"/acceleration-charts?shipIndex={string.Join(",", shipIndexes)}");
     }
 
     private void UpdateUrl()

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -215,7 +215,7 @@
                 }
                 else
                 {
-                    var tmpSc= shipStatsContainerCache.First().Value ?? new ShipStatsContainer();
+                    var tmpSc= shipStatsContainerCache.Values.FirstOrDefault(x => x is not null) ?? new ShipStatsContainer();
                     var viewModel = await tmpSc.GetShipViewModel(container.ShipIndex, container.BuildString);
                     
                     List<(string, float)>? modifiers = viewModel?.UpgradePanelViewModel.GetModifierList();

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -243,7 +243,7 @@
     private async Task OpenAccelerationCharts()
     {
         var shipIndexes = await StoreBuildsForCharts();
-        NavManager.NavigateTo($"/acceleration-charts?shipIndex={string.Join(",", shipIndexes)}");
+        NavManager.NavigateTo($"/acceleration-charts?shipIndexes={string.Join(",", shipIndexes)}");
     }
 
     private void UpdateUrl()

--- a/WoWsShipBuilder.Web/Pages/UserSettings.razor
+++ b/WoWsShipBuilder.Web/Pages/UserSettings.razor
@@ -21,7 +21,7 @@
             <MudCard Outlined>
                 <MudCardHeader>
                     <CardHeaderAvatar>
-                        <MudIcon Icon="@Icons.Filled.Info"/>
+                        <MudIcon Icon="@Icons.Material.Filled.Info"/>
                     </CardHeaderAvatar>
                     <CardHeaderContent>
                         <MudText Typo="Typo.h6">@Localizer.GetAppLocalization(nameof(Translation.WebApp_ApplicationInfo)).Localization</MudText>

--- a/WoWsShipBuilder.Web/Services/VmCache.cs
+++ b/WoWsShipBuilder.Web/Services/VmCache.cs
@@ -2,7 +2,7 @@
 
 namespace WoWsShipBuilder.Web.Services;
 
-public class VmCacheService
+public class VmCache
 {
     private readonly Dictionary<Guid, VmCacheEntry?> cacheEntries = new();
 

--- a/WoWsShipBuilder.Web/Services/VmCacheService.cs
+++ b/WoWsShipBuilder.Web/Services/VmCacheService.cs
@@ -1,0 +1,23 @@
+﻿using WoWsShipBuilder.Web.ViewModels;
+
+namespace WoWsShipBuilder.Web.Services;
+
+public class VmCacheService
+{
+    private readonly Dictionary<Guid, VmCacheEntry?> cacheEntries = new();
+
+    public VmCacheEntry? this[Guid id]
+    {
+        get => cacheEntries.GetValueOrDefault(id, default);
+        set => cacheEntries[id] = value;
+    }
+
+    public VmCacheEntry? GetOrDefault(Guid id) => cacheEntries.GetValueOrDefault(id, default);
+
+    public bool RemoveEntry(Guid id) => cacheEntries.Remove(id);
+}
+
+public sealed record VmCacheEntry(ShipViewModel ViewModel)
+{
+    public string BuildName { get; set; } = string.Empty;
+}

--- a/WoWsShipBuilder.Web/Utility/Helpers.cs
+++ b/WoWsShipBuilder.Web/Utility/Helpers.cs
@@ -76,7 +76,7 @@ public static class Helpers
             shipUpgrades.Add(shipUpgrade);
         }
     }
-  
+
     public static List<ShipUpgrade> GetShipConfigurationFromBuild(IEnumerable<string> storedData, List<ShipUpgrade> upgrades)
     {
         var results = new List<ShipUpgrade>();
@@ -112,11 +112,11 @@ public static class Helpers
 
         return redirectedUrl;
     }
-  
+
     public static bool IsAprilFool()
     {
-        //For debugging
-        //return DateTime.Now.Minute > 30;
+        // For debugging
+        // Return DateTime.Now.Minute > 30;
         return DateTime.Now is { Month: 4, Day: 1 };
     }
 

--- a/WoWsShipBuilder.Web/Utility/Helpers.cs
+++ b/WoWsShipBuilder.Web/Utility/Helpers.cs
@@ -89,7 +89,7 @@ public static class Helpers
         return results;
     }
 
-    public static async Task<string?> RetrieveLongUrl(string shortUrl)
+    public static async Task<string?> RetrieveLongUrlFromShortLink(string shortUrl)
     {
         // this allows you to set the settings so that we can get the redirect url
         using HttpClient client = new(new HttpClientHandler

--- a/WoWsShipBuilder.Web/Utility/Validation.cs
+++ b/WoWsShipBuilder.Web/Utility/Validation.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.AspNetCore.WebUtilities;
+using WoWsShipBuilder.Core.Builds;
+using WoWsShipBuilder.Core.Localization;
+
+namespace WoWsShipBuilder.Web.Utility;
+
+public static class Validation
+{
+    public static async Task<BuildStringValidationResult> ValidateBuildString(string buildStr, string selectedShipIndex, ILocalizer localizer, string shortUrlUriPrefix)
+    {
+        if (string.IsNullOrWhiteSpace(buildStr))
+        {
+            return new(false, null);
+        }
+
+        if (buildStr.Contains(shortUrlUriPrefix))
+        {
+            string? longUrl = await Helpers.RetrieveLongUrl(buildStr);
+
+            if (longUrl is not null && QueryHelpers.ParseQuery(longUrl).TryGetValue("build", out var buildStrFromUrl))
+            {
+                buildStr = buildStrFromUrl.ToString();
+            }
+            else
+            {
+                return new(false, localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild)));
+            }
+        }
+
+        if (QueryHelpers.ParseQuery(buildStr).TryGetValue("build", out var buildStringFromUrl))
+        {
+            buildStr = buildStringFromUrl.ToString();
+        }
+
+        // this is needed to avoid executing the try/catch even when we already know it is going to fail and so get a better performance
+        if (buildStr.Contains(';'))
+        {
+            try
+            {
+                var build = Build.CreateBuildFromString(buildStr);
+                if (selectedShipIndex.Equals(build.ShipIndex))
+                {
+                    return new(true, buildStr);
+                }
+
+                return new(false, $"{localizer.SimpleAppLocalization(nameof(Translation.Validation_Incompatibility))}. {localizer.SimpleAppLocalization(nameof(Translation.Validation_SelectedShip))}: {localizer.GetGameLocalization(selectedShipIndex + "_FULL").Localization} ≠ {localizer.SimpleAppLocalization(nameof(Translation.Validation_ShipInBuild))}: {localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}");
+            }
+            catch (FormatException)
+            {
+                return new(false, localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild)));
+            }
+        }
+
+        return new(false, localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild)));
+    }
+
+    public sealed record BuildStringValidationResult(bool IsValidBuildString, string? ValidationMessage);
+}

--- a/WoWsShipBuilder.Web/Utility/Validation.cs
+++ b/WoWsShipBuilder.Web/Utility/Validation.cs
@@ -14,7 +14,7 @@ public static class Validation
             return new(null, validatedBuildString);
         }
 
-        if (buildStr.Contains(shortUrlUriPrefix))
+        if (buildStr.Contains(shortUrlUriPrefix.Last().Equals('/') ? shortUrlUriPrefix : shortUrlUriPrefix + '/'))
         {
             string? longUrl = await Helpers.RetrieveLongUrlFromShortLink(buildStr);
 
@@ -58,9 +58,9 @@ public static class Validation
 
     public static string? ValidateBuildName(string buildName)
     {
-        var invalidChars = Path.GetInvalidFileNameChars().ToList();
+        List<char> invalidChars = Path.GetInvalidFileNameChars().ToList();
         invalidChars.Add(';');
-        var invalidCharsInBuildName = invalidChars.FindAll(buildName.Contains);
+        List<char> invalidCharsInBuildName = invalidChars.FindAll(buildName.Contains);
         return invalidCharsInBuildName.Any() ? $"Invalid characters {string.Join(' ', invalidCharsInBuildName)}" : null;
     }
 

--- a/WoWsShipBuilder.Web/Utility/Validation.cs
+++ b/WoWsShipBuilder.Web/Utility/Validation.cs
@@ -16,7 +16,7 @@ public static class Validation
 
         if (buildStr.Contains(shortUrlUriPrefix))
         {
-            string? longUrl = await Helpers.RetrieveLongUrl(buildStr);
+            string? longUrl = await Helpers.RetrieveLongUrlFromShortLink(buildStr);
 
             if (longUrl is not null && QueryHelpers.ParseQuery(longUrl).TryGetValue("build", out var buildStrFromUrl))
             {

--- a/WoWsShipBuilder.Web/Utility/Validation.cs
+++ b/WoWsShipBuilder.Web/Utility/Validation.cs
@@ -56,5 +56,13 @@ public static class Validation
         return new(localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild)), validatedBuildString);
     }
 
+    public static string? ValidateBuildName(string buildName)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars().ToList();
+        invalidChars.Add(';');
+        var invalidCharsInBuildName = invalidChars.FindAll(buildName.Contains);
+        return invalidCharsInBuildName.Any() ? $"Invalid characters {string.Join(' ', invalidCharsInBuildName)}" : null;
+    }
+
     public sealed record BuildStringValidationResult(string? ValidationMessage, string ValidatedBuildString);
 }

--- a/WoWsShipBuilder.Web/Utility/Validation.cs
+++ b/WoWsShipBuilder.Web/Utility/Validation.cs
@@ -8,9 +8,10 @@ public static class Validation
 {
     public static async Task<BuildStringValidationResult> ValidateBuildString(string buildStr, string selectedShipIndex, ILocalizer localizer, string shortUrlUriPrefix)
     {
+        var validatedBuildString = string.Empty;
         if (string.IsNullOrWhiteSpace(buildStr))
         {
-            return new(false, null);
+            return new(null, validatedBuildString);
         }
 
         if (buildStr.Contains(shortUrlUriPrefix))
@@ -23,7 +24,7 @@ public static class Validation
             }
             else
             {
-                return new(false, localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild)));
+                return new( localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild)), validatedBuildString);
             }
         }
 
@@ -40,19 +41,20 @@ public static class Validation
                 var build = Build.CreateBuildFromString(buildStr);
                 if (selectedShipIndex.Equals(build.ShipIndex))
                 {
-                    return new(true, buildStr);
+                    validatedBuildString = buildStr;
+                    return new(null, validatedBuildString);
                 }
 
-                return new(false, $"{localizer.SimpleAppLocalization(nameof(Translation.Validation_Incompatibility))}. {localizer.SimpleAppLocalization(nameof(Translation.Validation_SelectedShip))}: {localizer.GetGameLocalization(selectedShipIndex + "_FULL").Localization} ≠ {localizer.SimpleAppLocalization(nameof(Translation.Validation_ShipInBuild))}: {localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}");
+                return new($"{localizer.SimpleAppLocalization(nameof(Translation.Validation_Incompatibility))}. {localizer.SimpleAppLocalization(nameof(Translation.Validation_SelectedShip))}: {localizer.GetGameLocalization(selectedShipIndex + "_FULL").Localization} ≠ {localizer.SimpleAppLocalization(nameof(Translation.Validation_ShipInBuild))}: {localizer.GetGameLocalization(build.ShipIndex + "_FULL").Localization}", validatedBuildString);
             }
             catch (FormatException)
             {
-                return new(false, localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild)));
+                return new(localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild)), validatedBuildString);
             }
         }
 
-        return new(false, localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild)));
+        return new(localizer.SimpleAppLocalization(nameof(Translation.Validation_InvalidBuild)), validatedBuildString);
     }
 
-    public sealed record BuildStringValidationResult(bool IsValidBuildString, string? ValidationMessage);
+    public sealed record BuildStringValidationResult(string? ValidationMessage, string ValidatedBuildString);
 }

--- a/WoWsShipBuilder.Web/WoWsShipBuilder.Web.csproj
+++ b/WoWsShipBuilder.Web/WoWsShipBuilder.Web.csproj
@@ -17,7 +17,7 @@
       <PackageReference Include="NLog.Web.AspNetCore" Version="5.2.1" />
       <PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
       <PackageReference Include="ReactiveUI.Blazor" Version="18.3.1" />
-      <PackageReference Include="MudBlazor" Version="6.0.17" />
+      <PackageReference Include="MudBlazor" Version="6.1.9" />
       <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
       <PackageReference Include="Sentry.NLog" Version="3.28.1" />
       <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="14.4.1" />

--- a/WoWsShipBuilder.Web/wwwroot/scripts/MouseEventHelper.js
+++ b/WoWsShipBuilder.Web/wwwroot/scripts/MouseEventHelper.js
@@ -1,6 +1,6 @@
 ﻿export function PreventMiddleClickDefault(id) {
     const element = document.getElementById(id);
-    if (element != null){
+    if (element != null) {
         element.removeEventListener("mousedown", handleMiddleClick);
         element.addEventListener("mousedown", handleMiddleClick);   
     }

--- a/WoWsShipBuilder.Web/wwwroot/scripts/MouseEventHelper.js
+++ b/WoWsShipBuilder.Web/wwwroot/scripts/MouseEventHelper.js
@@ -1,8 +1,8 @@
 ﻿export function PreventMiddleClickDefault(id) {
     const element = document.getElementById(id);
-    if (element != null) {
+    if (element !== null) {
         element.removeEventListener("mousedown", handleMiddleClick);
-        element.addEventListener("mousedown", handleMiddleClick);   
+        element.addEventListener("mousedown", handleMiddleClick);
     }
 }
 

--- a/WoWsShipBuilder.Web/wwwroot/scripts/MouseEventHelper.js
+++ b/WoWsShipBuilder.Web/wwwroot/scripts/MouseEventHelper.js
@@ -1,7 +1,9 @@
 ﻿export function PreventMiddleClickDefault(id) {
     const element = document.getElementById(id);
-    element.removeEventListener("mousedown", handleMiddleClick);
-    element.addEventListener("mousedown", handleMiddleClick);
+    if (element != null){
+        element.removeEventListener("mousedown", handleMiddleClick);
+        element.addEventListener("mousedown", handleMiddleClick);   
+    }
 }
 
 function handleMiddleClick(event) {


### PR DESCRIPTION
Add a cache to store viewmodels in order to drastically reduce loading time when opening several ships together.
Add additional stats for submarines and homing torps.
Fix several minor bugs (check previous commits descriptions).

Update to MudBlazor 6.1.9

Require new data conversion.