### PR TITLE
Migrate logging from NLog to Microsoft.Extensions.Logging

### DIFF
--- a/WoWsShipBuilder.Core.Test/BuildTests/BuildDeserialization.cs
+++ b/WoWsShipBuilder.Core.Test/BuildTests/BuildDeserialization.cs
@@ -6,6 +6,7 @@ using NLog;
 using NUnit.Framework;
 using WoWsShipBuilder.Core.Builds;
 using WoWsShipBuilder.DataStructures;
+using NullLogger = Microsoft.Extensions.Logging.Abstractions.NullLogger;
 
 namespace WoWsShipBuilder.Core.Test.BuildTests;
 
@@ -17,11 +18,9 @@ public class BuildDeserialization
     {
         const string buildString = @"bJBLTsMwEIbv4nWRbNoF6a6xKqCIENV9qELImipWahE/ZDsCCXEyFhyJKzBOyI7lfP/MfKP5+fr+IGWvu6YCo8iSJBXT1TkDMiPiov29bdQ7BvVGlJTdIK0gaWcRbcCDRfDomr5TkSyfsWu/KhiTJaNytd1JsXviD9iC/C7zExhITrJisRipyFT0bqzWxXycXVe3f7MvM7L3bYBmEGDFwSfQ2V/zI6Us3/mqu26KnY29gfN0ED9RWkgeIF54UG91UEb3JuswQdNWtcr+k8yl8C4lFSaOu4VuLUyi4WsHFeLwjOvPXwAAAP//AwA=";
         const string buildName = "test-build";
-        var logger = new Mock<ILogger>();
 
-        var build = Build.CreateBuildFromString(buildString, logger.Object);
+        var build = Build.CreateBuildFromString(buildString, NullLogger.Instance);
 
-        logger.Verify(l => l.Info(It.IsAny<string>()), Times.Never());
         build.BuildName.Should().Be(buildName);
         build.BuildVersion.Should().Be(Build.CurrentBuildVersion);
         build.Modules.Should().NotBeEmpty();
@@ -38,11 +37,9 @@ public class BuildDeserialization
     {
         const string buildString = "bJDPSgMxEIffJecKCe3B7a0bilrpujStUqSEKRu2obtJyB8UxCfz4CP5Ck523ZvH+X4z8w3z8/X9Qcqku6aCXpEliSrEm3MGZEbERbsH06h3DOqNKCm7RVpB1NYg2oADg2Brm9SpQJav2HVYFYzJklG52u2l2D/xR2xBfp/5EXqIVrJisRipyFQkO1brYj7Orqu7v9nTjBxc66EZBFhxcBF09tf8hVKW77zqrptia0Lq4TwdxI+UFpJ7CBfu1VvtVa9Tn3WYoGmnWmX+SeZSOBuj8hPH3UK3BibR8LVn5cPwDPb5CwAA//8DAA==";
         const string buildName = "test-build";
-        var logger = new Mock<ILogger>();
 
-        var build = Build.CreateBuildFromString(buildString, logger.Object);
+        var build = Build.CreateBuildFromString(buildString, NullLogger.Instance);
 
-        logger.Verify(l => l.Info("Upgrading build {}({}) from build version {} to current version.", buildName, build.Hash, 1), Times.Once());
         build.BuildName.Should().Be(buildName);
         build.BuildVersion.Should().Be(Build.CurrentBuildVersion);
         build.Modules.Should().NotBeEmpty();

--- a/WoWsShipBuilder.Core.Test/HttpTest/AwsClientTest.cs
+++ b/WoWsShipBuilder.Core.Test/HttpTest/AwsClientTest.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
@@ -43,7 +44,7 @@ namespace WoWsShipBuilder.Core.Test.HttpTest
         [Test]
         public async Task DownloadFile_LocalDirectoryDoesNotExist()
         {
-            var client = new AwsClient(mockDataService, appDataHelper, messageHandlerMock.Object);
+            var client = new AwsClient(mockDataService, appDataHelper, NullLogger<AwsClient>.Instance, messageHandlerMock.Object);
             var filePath = @"json/live/VersionInfo.json";
             var requestUri = new Uri("https://cloudfront/api/live/VersionInfo.json");
             mockFileSystem.FileExists(filePath).Should().BeFalse();
@@ -65,7 +66,7 @@ namespace WoWsShipBuilder.Core.Test.HttpTest
                 .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound))
                 .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 
-            var client = new AwsClient(mockDataService, appDataHelper, messageHandlerMock.Object);
+            var client = new AwsClient(mockDataService, appDataHelper, NullLogger<AwsClient>.Instance, messageHandlerMock.Object);
             var filePath = @"json/live/VersionInfo.json";
             var requestUri = new Uri("https://cloudfront/api/live/VersionInfo.json");
             mockFileSystem.FileExists(filePath).Should().BeFalse();

--- a/WoWsShipBuilder.Core.Test/LocalDataUpdaterTests/CheckJsonFileVersions.cs
+++ b/WoWsShipBuilder.Core.Test/LocalDataUpdaterTests/CheckJsonFileVersions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using WoWsShipBuilder.Core.DataProvider;
@@ -24,7 +25,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
             mockFileSystem.AddDirectory(appDataHelper.Object.GetDataPath(ServerType.Live));
 
             // Act
-            var result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new()).CheckJsonFileVersions(ServerType.Live);
+            var result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new(), NullLogger<LocalDataUpdater>.Instance).CheckJsonFileVersions(ServerType.Live);
 
             // Assert
             result.AvailableFileUpdates.Should()
@@ -55,7 +56,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
             appDataHelper.Setup(x => x.GetCurrentVersionInfo(ServerType.Live)).ReturnsAsync(localVersionInfo);
 
             // Act
-            var result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new()).CheckJsonFileVersions(ServerType.Live);
+            var result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new(), NullLogger<LocalDataUpdater>.Instance).CheckJsonFileVersions(ServerType.Live);
 
             // Assert
             result.AvailableFileUpdates.Should().HaveCount(2);
@@ -74,7 +75,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
             appDataHelper.Setup(x => x.GetCurrentVersionInfo(ServerType.Live)).ReturnsAsync(testVersionInfo);
 
             // Act
-            var result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new()).CheckJsonFileVersions(ServerType.Live);
+            var result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new(), NullLogger<LocalDataUpdater>.Instance).CheckJsonFileVersions(ServerType.Live);
 
             // Assert
             result.AvailableFileUpdates.Should().BeEmpty();
@@ -116,7 +117,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
             appDataHelper.Setup(x => x.GetCurrentVersionInfo(ServerType.Live)).ReturnsAsync(localVersionInfo);
 
             // Act
-            var result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new()).CheckJsonFileVersions(ServerType.Live);
+            var result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new(), NullLogger<LocalDataUpdater>.Instance).CheckJsonFileVersions(ServerType.Live);
 
             // Assert
             result.AvailableFileUpdates.Should().BeEmpty();

--- a/WoWsShipBuilder.Core.Test/LocalDataUpdaterTests/ShouldUpdaterRun.cs
+++ b/WoWsShipBuilder.Core.Test/LocalDataUpdaterTests/ShouldUpdaterRun.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using WoWsShipBuilder.Core.DataProvider;
@@ -22,7 +23,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
             };
 
             // Act
-            bool result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, appSettings).ShouldUpdaterRun(ServerType.Live);
+            bool result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, appSettings, NullLogger<LocalDataUpdater>.Instance).ShouldUpdaterRun(ServerType.Live);
 
             // Assert
             result.Should().BeTrue();
@@ -39,7 +40,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
             appDataHelper.Setup(x => x.GetCurrentVersionInfo(ServerType.Live)).ReturnsAsync(CreateTestVersionInfo(1, GameVersion.Default));
 
             // Act
-            bool result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, appSettings).ShouldUpdaterRun(ServerType.Live);
+            bool result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, appSettings, NullLogger<LocalDataUpdater>.Instance).ShouldUpdaterRun(ServerType.Live);
 
             // Assert
             result.Should().BeFalse();
@@ -56,7 +57,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
             appDataHelper.Setup(x => x.GetCurrentVersionInfo(ServerType.Live)).ReturnsAsync((VersionInfo?)null);
 
             // Act
-            bool result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, appSettings).ShouldUpdaterRun(ServerType.Live);
+            bool result = await new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, appSettings, NullLogger<LocalDataUpdater>.Instance).ShouldUpdaterRun(ServerType.Live);
 
             // Assert
             result.Should().BeTrue();

--- a/WoWsShipBuilder.Core.Test/LocalDataUpdaterTests/ValidateData.cs
+++ b/WoWsShipBuilder.Core.Test/LocalDataUpdaterTests/ValidateData.cs
@@ -2,6 +2,7 @@
 using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using WoWsShipBuilder.Core.DataProvider;
@@ -16,7 +17,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
         public async Task ValidateData_NoLocalVersionInfo_False()
         {
             // Arrange
-            var updater = new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new());
+            var updater = new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new(), NullLogger<LocalDataUpdater>.Instance);
 
             // Act
             var result = await updater.ValidateData(ServerType.Live, @"json/live");
@@ -32,7 +33,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
             var versionInfo = CreateTestVersionInfo(1, GameVersion.Default);
             appDataHelper.Setup(x => x.GetCurrentVersionInfo(ServerType.Live)).ReturnsAsync(versionInfo);
             mockFileSystem.AddDirectory(@"json/live/Ability");
-            var updater = new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new());
+            var updater = new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new(), NullLogger<LocalDataUpdater>.Instance);
 
             // Act
             var result = await updater.ValidateData(ServerType.Live, @"json/live");
@@ -59,7 +60,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
             mockFileSystem.AddFile(@"json/live/Ability/Common.json", new("test"));
             mockFileSystem.AddFile(@"json/live/Ship/Japan.json", new("test"));
             mockFileSystem.AddFile(@"json/live/Ship/Germany.json", new("test"));
-            var updater = new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new());
+            var updater = new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new(), NullLogger<LocalDataUpdater>.Instance);
 
             // Act
             var result = await updater.ValidateData(ServerType.Live, @"json/live");
@@ -76,7 +77,7 @@ namespace WoWsShipBuilder.Core.Test.LocalDataUpdaterTests
             appDataHelper.Setup(x => x.GetCurrentVersionInfo(ServerType.Live)).ReturnsAsync(versionInfo);
             mockFileSystem.AddFile(@"json/live/Ability/Common.json", new MockFileData("test"));
             mockFileSystem.AddFile(@"json/live/Ship/Japan.json", new MockFileData("test"));
-            var updater = new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new());
+            var updater = new LocalDataUpdater(mockFileSystem, awsClientMock.Object, appDataHelper.Object, new(), NullLogger<LocalDataUpdater>.Instance);
 
             // Act
             var result = await updater.ValidateData(ServerType.Live, @"json/live");

--- a/WoWsShipBuilder.Core/Builds/Build.cs
+++ b/WoWsShipBuilder.Core/Builds/Build.cs
@@ -4,8 +4,8 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using NLog;
 using WoWsShipBuilder.Core.Utility;
 using WoWsShipBuilder.DataStructures;
 
@@ -104,7 +104,7 @@ public class Build
         }
         catch (Exception e)
         {
-            effectiveLogger.Warn(e, $"The string {buildString} is not in a valid format for a Build object");
+            effectiveLogger.LogWarning(e, "The string {BuildString} is not in a valid format for a Build object", buildString);
             throw new FormatException("Invalid build string format", e);
         }
     }
@@ -141,18 +141,18 @@ public class Build
         if (oldBuild.BuildVersion < 3)
         {
             oldBuild.Signals = ReduceToIndex(oldBuild.Signals).ToList();
-            logger.Debug("Reducing signal names to index for build {}", oldBuild.Hash);
+            logger.LogDebug("Reducing signal names to index for build {}", oldBuild.Hash);
         }
 
         if (oldBuild.BuildVersion < 4)
         {
             oldBuild.Modules = ReduceToIndex(oldBuild.Modules).ToList();
-            logger.Debug("Reducing module names to index for build {}", oldBuild.Hash);
+            logger.LogDebug("Reducing module names to index for build {}", oldBuild.Hash);
         }
 
         if (oldBuild.BuildVersion < CurrentBuildVersion)
         {
-            logger.Info("Upgrading build {}({}) from build version {} to current version.", oldBuild.BuildName, oldBuild.Hash, oldBuild.BuildVersion);
+            logger.LogInformation("Upgrading build {OldBuildName}({OldBuildHash}) from build version {OldBuildVersion} to current version", oldBuild.BuildName, oldBuild.Hash, oldBuild.BuildVersion);
             oldBuild.BuildVersion = CurrentBuildVersion;
         }
 

--- a/WoWsShipBuilder.Core/DataContainers/Armament/PingerGunDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Armament/PingerGunDataContainer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.Core.Extensions;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataElements.DataElements;
@@ -46,7 +47,7 @@ namespace WoWsShipBuilder.Core.DataContainers
             var pingerUpgrade = shipConfiguration.FirstOrDefault(c => c.UcType == ComponentType.Sonar);
             if (pingerUpgrade is null && ship.PingerGunList.Count is 1)
             {
-                Logging.Logger.Warn("No sonar upgrade information found for ship {ShipName} even though there is one sonar module available.", ship.Name);
+                Logging.Logger.LogWarning("No sonar upgrade information found for ship {ShipName} even though there is one sonar module available", ship.Name);
                 return null;
             }
 
@@ -62,7 +63,7 @@ namespace WoWsShipBuilder.Core.DataContainers
             }
             else
             {
-                Logging.Logger.Warn("Unable to retrieve sonar component from upgrade info for ship {} and ship upgrade {}", ship.Index, pingerUpgrade.Name);
+                Logging.Logger.LogWarning("Unable to retrieve sonar component from upgrade info for ship {} and ship upgrade {}", ship.Index, pingerUpgrade.Name);
                 pingerGun = ship.PingerGunList.First().Value;
             }
 

--- a/WoWsShipBuilder.Core/DataContainers/Armament/SecondaryBatteryDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Armament/SecondaryBatteryDataContainer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.Core.Extensions;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataElements.DataElements;
@@ -111,7 +112,7 @@ public partial record SecondaryBatteryDataContainer : DataContainerBase
             catch (KeyNotFoundException e)
             {
                 // TODO: fix issue properly for next minor release
-                Logging.Logger.Warn(e, "One or more keys of the secondary data were not found.");
+                Logging.Logger.LogWarning(e, "One or more keys of the secondary data were not found");
                 shellData = new()
                 {
                     Name = "Error",

--- a/WoWsShipBuilder.Core/DataContainers/Ship/ConsumableDataContainer.cs
+++ b/WoWsShipBuilder.Core/DataContainers/Ship/ConsumableDataContainer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.Core.DataProvider;
 using WoWsShipBuilder.Core.Extensions;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
@@ -50,7 +51,7 @@ public partial record ConsumableDataContainer : DataContainerBase
         var usingFallback = false;
         if (!(AppData.ConsumableList?.TryGetValue(consumableIdentifier, out var consumable) ?? false))
         {
-            Logging.Logger.Error("Consumable {} not found in cached consumable list. Using dummy consumable instead.", consumableIdentifier);
+            Logging.Logger.LogError("Consumable {Identifier} not found in cached consumable list. Using dummy consumable instead", consumableIdentifier);
             usingFallback = true;
             consumable = new()
             {
@@ -259,7 +260,7 @@ public partial record ConsumableDataContainer : DataContainerBase
         }
         else if (usingFallback)
         {
-            Logging.Logger.Warn("Skipping consumable modifier calculation due to fallback consumable.");
+            Logging.Logger.LogWarning("Skipping consumable modifier calculation due to fallback consumable.");
         }
 
         var consumableDataContainer = new ConsumableDataContainer

--- a/WoWsShipBuilder.Core/DataProvider/AppData.cs
+++ b/WoWsShipBuilder.Core/DataProvider/AppData.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.Core.Builds;
 using WoWsShipBuilder.Core.Utility;
 using WoWsShipBuilder.DataStructures;
@@ -83,7 +84,7 @@ public static class AppData
         AircraftCache.Clear();
         ShipDictionary.Clear();
         DataVersion = null;
-        Logging.Logger.Info("Cleared all appdata caches.");
+        Logging.Logger.LogInformation("Cleared all appdata caches");
     }
 
     /// <summary>

--- a/WoWsShipBuilder.Core/DataProvider/DesktopAppDataService.cs
+++ b/WoWsShipBuilder.Core/DataProvider/DesktopAppDataService.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.Core.Builds;
 using WoWsShipBuilder.Core.Services;
 using WoWsShipBuilder.Core.Settings;
@@ -114,13 +115,13 @@ public class DesktopAppDataService : IAppDataService, IUserDataService
     public async Task LoadLocalFilesAsync(ServerType serverType)
     {
         var sw = Stopwatch.StartNew();
-        Logging.Logger.Debug("Loading local files from disk.");
+        Logging.Logger.LogDebug("Loading local files from disk");
         AppData.ResetCaches();
         var localVersionInfo = await GetCurrentVersionInfo(serverType) ?? throw new InvalidOperationException("No local data found");
         AppData.DataVersion = localVersionInfo.CurrentVersion.MainVersion.ToString(3) + "#" + localVersionInfo.CurrentVersion.DataIteration;
 
         var dataRootInfo = fileSystem.DirectoryInfo.New(GetDataPath(serverType));
-        IDirectoryInfo[]? categories = dataRootInfo.GetDirectories();
+        IDirectoryInfo[] categories = dataRootInfo.GetDirectories();
 
         // Multiple categories can be loaded simultaneously without concurrency issues because every cache is only used by one category.
         await Parallel.ForEachAsync(categories, async (category, ct) =>
@@ -138,7 +139,7 @@ public class DesktopAppDataService : IAppDataService, IUserDataService
         });
 
         sw.Stop();
-        Logging.Logger.Debug("Loaded local files in {}", sw.Elapsed);
+        Logging.Logger.LogDebug("Loaded local files in {}", sw.Elapsed);
     }
 
     public async Task<T?> DeserializeFile<T>(string filePath)
@@ -150,7 +151,7 @@ public class DesktopAppDataService : IAppDataService, IUserDataService
 
         if (!fileSystem.File.Exists(filePath))
         {
-            Logging.Logger.Warn($"Tried to load file {filePath}, but it was not found.");
+            Logging.Logger.LogWarning("Tried to load file {FilePath}, but it was not found", filePath);
             return default;
         }
 

--- a/WoWsShipBuilder.Core/HttpClients/RetryHttpHandler.cs
+++ b/WoWsShipBuilder.Core/HttpClients/RetryHttpHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace WoWsShipBuilder.Core.HttpClients;
 
@@ -23,10 +24,10 @@ public class RetryHttpHandler : DelegatingHandler
                 return response;
             }
 
-            Logging.Logger.Info("Http request for uri {0} failed. Retry attempt {1}", request.RequestUri, i + 1);
+            Logging.Logger.LogInformation("Http request for uri {RequestUri} failed. Retry attempt {Attempt}", request.RequestUri, i + 1);
         }
 
-        Logging.Logger.Warn("Reached maximum number of retry requests for uri {0}. Continuing with last result.", request.RequestUri);
+        Logging.Logger.LogWarning("Reached maximum number of retry requests for uri {RequestUri}. Continuing with last result", request.RequestUri);
         return await base.SendAsync(request, cancellationToken);
     }
 }

--- a/WoWsShipBuilder.Core/Logging.cs
+++ b/WoWsShipBuilder.Core/Logging.cs
@@ -1,10 +1,20 @@
-﻿using NLog;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NLog;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+using NullLogger = Microsoft.Extensions.Logging.Abstractions.NullLogger;
 
 namespace WoWsShipBuilder.Core;
 
 public static class Logging
 {
-    public static Logger Logger { get; } = LogManager.GetLogger("ShipBuilder");
+    public static ILogger Logger { get; private set; } = NullLogger.Instance;
 
-    public static Logger GetLogger(string name = "ShipBuilder") => LogManager.GetLogger(name);
+    public static ILoggerFactory LoggerFactory { get; private set; } = NullLoggerFactory.Instance;
+
+    public static void Initialize(ILoggerFactory loggerFactory)
+    {
+        LoggerFactory = loggerFactory;
+        Logger = LoggerFactory.CreateLogger("WoWsShipBuilder");
+    }
 }

--- a/WoWsShipBuilder.Core/Utility/GameDataHelper.cs
+++ b/WoWsShipBuilder.Core/Utility/GameDataHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.DataStructures.Aircraft;
 using WoWsShipBuilder.DataStructures.Captain;
@@ -17,7 +18,7 @@ public static class GameDataHelper
     {
         if (index.Length < 7)
         {
-            Logging.Logger.Error("Invalid index, received value {}.", index);
+            Logging.Logger.LogError("Invalid index, received value {Index}", index);
             return Nation.Common;
         }
 

--- a/WoWsShipBuilder.Core/WoWsShipBuilder.Core.csproj
+++ b/WoWsShipBuilder.Core/WoWsShipBuilder.Core.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
       <PackageReference Include="NLog" Version="5.1.1" />
       <PackageReference Include="Roslyn.System.IO.Abstractions.Analyzers" Version="12.2.19">

--- a/WoWsShipBuilder.UI/Converters/ConsumableUiConverter.cs
+++ b/WoWsShipBuilder.UI/Converters/ConsumableUiConverter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Media.Imaging;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.DataContainers;
 
@@ -44,7 +45,7 @@ namespace WoWsShipBuilder.UI.Converters
                 }
             }
 
-            Logging.Logger.Trace("No matching processing path for consumable data conversion found. Element 1: {0}, Element 2: {1}", values[0], values[1]);
+            Logging.Logger.LogTrace("No matching processing path for consumable data conversion found. Element 1: {Values0}, Element 2: {Values1}", values[0], values[1]);
             return new BindingNotification(new NotSupportedException());
         }
     }

--- a/WoWsShipBuilder.UI/Converters/ImagePathConverter.cs
+++ b/WoWsShipBuilder.UI/Converters/ImagePathConverter.cs
@@ -9,9 +9,9 @@ using Avalonia;
 using Avalonia.Data.Converters;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using NLog;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Splat;
-using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.DataContainers;
 using WoWsShipBuilder.Core.Services;
 using WoWsShipBuilder.DataStructures;
@@ -20,6 +20,7 @@ using WoWsShipBuilder.DataStructures.Exterior;
 using WoWsShipBuilder.DataStructures.Ship;
 using WoWsShipBuilder.DataStructures.Upgrade;
 using WoWsShipBuilder.UI.Extensions;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace WoWsShipBuilder.UI.Converters
 {
@@ -28,18 +29,20 @@ namespace WoWsShipBuilder.UI.Converters
     /// </summary>
     class ImagePathConverter : IValueConverter
     {
-        private static readonly Logger Logger = Logging.GetLogger("ImagePathConverter");
+        // TODO: initialize properly
+        private readonly ILogger logger;
 
         private readonly IFileSystem fileSystem;
 
         public ImagePathConverter()
-            : this(new FileSystem())
+            : this(Locator.Current.GetService<IFileSystem>() ?? new FileSystem(), Locator.Current.GetService<ILogger<ImagePathConverter>>() ?? NullLogger<ImagePathConverter>.Instance)
         {
         }
 
-        internal ImagePathConverter(IFileSystem fileSystem)
+        internal ImagePathConverter(IFileSystem fileSystem, ILogger<ImagePathConverter> logger)
         {
             this.fileSystem = fileSystem;
+            this.logger = logger;
         }
 
         [SuppressMessage("Spacing Rules", "SA1008", Justification = "StyleCop error results in false positive.")]
@@ -52,7 +55,7 @@ namespace WoWsShipBuilder.UI.Converters
             {
                 case string imageName when parameter is string type:
                 {
-                    Logger.Debug("Processing regular image name.");
+                    logger.LogDebug("Processing regular image name");
                     Uri? uri = null;
 
                     if (imageName.Equals("blank"))
@@ -67,7 +70,7 @@ namespace WoWsShipBuilder.UI.Converters
                     else if (type.Equals("ship", StringComparison.InvariantCultureIgnoreCase))
                     {
                         // TODO: remove locator invocation
-                        string? imagePath = fileSystem.Path.Combine(Locator.Current.GetRequiredService<IAppDataService>().AppDataImageDirectory, "Ships", $"{imageName}.png");
+                        string imagePath = fileSystem.Path.Combine(Locator.Current.GetRequiredService<IAppDataService>().AppDataImageDirectory, "Ships", $"{imageName}.png");
                         Stream stream;
                         if (fileSystem.File.Exists(imagePath))
                         {
@@ -75,19 +78,19 @@ namespace WoWsShipBuilder.UI.Converters
                         }
                         else
                         {
-                            Logger.Warn("Using fallback error icon because image '{}' was not found.", imagePath);
+                            logger.LogWarning("Using fallback error icon because image {ImagePath} was not found", imagePath);
                             stream = LoadErrorIcon(assets);
                         }
 
                         return new Bitmap(stream);
                     }
 
-                    return new Bitmap(LoadEmbeddedAsset(assets, uri));
+                    return new Bitmap(LoadEmbeddedAsset(assets, uri, logger));
                 }
 
                 case Ship or ShipSummary:
                 {
-                    Logger.Debug("Processing nation flag.");
+                    logger.LogDebug("Processing nation flag");
                     string shipIndex = default!;
                     string shipNation = default!;
 
@@ -110,12 +113,12 @@ namespace WoWsShipBuilder.UI.Converters
                         uri = new($"avares://{assemblyName}/Assets/nation_flags/flag_{shipNation}.png");
                     }
 
-                    return new Bitmap(LoadEmbeddedAsset(assets, uri));
+                    return new Bitmap(LoadEmbeddedAsset(assets, uri, logger));
                 }
 
                 case Modernization modernization:
                 {
-                    Logger.Debug("Processing modernization.");
+                    logger.LogDebug("Processing modernization");
                     Uri uri;
                     if (modernization.Index != null)
                     {
@@ -126,12 +129,12 @@ namespace WoWsShipBuilder.UI.Converters
                         uri = new($"avares://{assemblyName}/Assets/modernization_icons/modernization_default3.png");
                     }
 
-                    return new Bitmap(LoadEmbeddedAsset(assets, uri));
+                    return new Bitmap(LoadEmbeddedAsset(assets, uri, logger));
                 }
 
                 case Consumable or (ShipConsumable, Consumable):
                 {
-                    Logger.Debug("Processing consumable.");
+                    logger.LogDebug("Processing consumable");
                     if (value is not Consumable consumable)
                     {
                         consumable = (((ShipConsumable, Consumable tmpConsumable))value).tmpConsumable;
@@ -140,21 +143,21 @@ namespace WoWsShipBuilder.UI.Converters
                     string iconName = string.IsNullOrEmpty(consumable.IconId) ? consumable.Name : consumable.IconId;
                     Uri uri = new($"avares://{assemblyName}/Assets/consumable_icons/consumable_{iconName}.png");
 
-                    return new Bitmap(LoadEmbeddedAsset(assets, uri));
+                    return new Bitmap(LoadEmbeddedAsset(assets, uri, logger));
                 }
 
                 case ConsumableDataContainer consumableUi:
                 {
-                    Logger.Debug("Processing consumableUI.");
+                    logger.LogDebug("Processing consumableUI");
                     string iconName = consumableUi.IconName;
                     Uri uri = new($"avares://{assemblyName}/Assets/consumable_icons/consumable_{iconName}.png");
 
-                    return new Bitmap(LoadEmbeddedAsset(assets, uri));
+                    return new Bitmap(LoadEmbeddedAsset(assets, uri, logger));
                 }
 
                 case Exterior exterior:
                 {
-                    Logger.Debug("Processing Exterior.");
+                    logger.LogDebug("Processing Exterior");
 
                     Uri? uri = null;
                     if (!string.IsNullOrEmpty(exterior.Name) && parameter != null && parameter.ToString()!.Equals("Flags", StringComparison.InvariantCultureIgnoreCase))
@@ -166,13 +169,13 @@ namespace WoWsShipBuilder.UI.Converters
                         uri = new($"avares://{assemblyName}/Assets/blank.png");
                     }
 
-                    return new Bitmap(LoadEmbeddedAsset(assets, uri));
+                    return new Bitmap(LoadEmbeddedAsset(assets, uri, logger));
                 }
 
                 default:
                 {
-                    Logger.Warn($"Unable to find handler for type {value?.GetType()}. Falling back to default implementation.");
-                    return new Bitmap(LoadEmbeddedAsset(assets, null));
+                    logger.LogWarning("Unable to find handler for type {Type}. Falling back to default implementation", value?.GetType());
+                    return new Bitmap(LoadEmbeddedAsset(assets, null, logger));
                 }
             }
         }
@@ -187,8 +190,9 @@ namespace WoWsShipBuilder.UI.Converters
         /// </summary>
         /// <param name="assetLoader">The <see cref="IAssetLoader"/> used to access embedded assets.</param>
         /// <param name="uri">The <see cref="Uri"/> of the asset.</param>
+        /// <param name="logger">The logger to use.</param>
         /// <returns>A stream of the asset or the error icon, if the asset did not exist.</returns>
-        private static Stream LoadEmbeddedAsset(IAssetLoader assetLoader, Uri? uri)
+        private static Stream LoadEmbeddedAsset(IAssetLoader assetLoader, Uri? uri, ILogger logger)
         {
             if (uri == null)
             {
@@ -202,7 +206,7 @@ namespace WoWsShipBuilder.UI.Converters
             }
             catch (Exception e) when (e is NullReferenceException or FileNotFoundException)
             {
-                Logger.Warn("Unable to find file for uri {0}, falling back to error icon.", uri);
+                logger.LogWarning("Unable to find file for uri {Uri}, falling back to error icon", uri);
                 result = LoadErrorIcon(assetLoader);
             }
 

--- a/WoWsShipBuilder.UI/DesignDataHelper.cs
+++ b/WoWsShipBuilder.UI/DesignDataHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
 using Avalonia.Controls;
+using Microsoft.Extensions.Logging.Abstractions;
 using WoWsShipBuilder.Core.Builds;
 using WoWsShipBuilder.Core.Data;
 using WoWsShipBuilder.Core.DataContainers;
@@ -38,7 +39,7 @@ public static class DesignDataHelper
 
     public static SettingsWindowViewModel SettingsWindowViewModel { get; } = new(new FileSystem(), new AvaloniaClipboardService(), PreviewAppDataService);
 
-    public static ShipWindowViewModel ShipWindowViewModel { get; } = new(new NavigationService(), new AvaloniaClipboardService(), DemoLocalizer, GetPreviewViewModelParams(ShipClass.Cruiser, 10, Nation.Usa));
+    public static ShipWindowViewModel ShipWindowViewModel { get; } = new(new NavigationService(), new AvaloniaClipboardService(), DemoLocalizer, NullLogger<ShipWindowViewModel>.Instance, GetPreviewViewModelParams(ShipClass.Cruiser, 10, Nation.Usa));
 
     public static Build CreateTestBuild(string name = "test-build") => new(name, null!, Nation.Common, null!, null!, null!, null!, null!, null!);
 

--- a/WoWsShipBuilder.UI/Program.cs
+++ b/WoWsShipBuilder.UI/Program.cs
@@ -2,83 +2,88 @@ using System;
 using System.Runtime.Versioning;
 using System.Threading;
 using Avalonia;
+using NLog;
+using Sentry;
 using Squirrel;
-using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.Services;
 using WoWsShipBuilder.UI.Extensions;
 using WoWsShipBuilder.UI.Settings;
 using WoWsShipBuilder.UI.Utilities;
 
-namespace WoWsShipBuilder.UI
+namespace WoWsShipBuilder.UI;
+
+class Program
 {
-    class Program
+    // Initialization code. Don't use any Avalonia, third-party APIs or any
+    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+    // yet and stuff might break.
+    public static void Main(string[] args)
     {
-        // Initialization code. Don't use any Avalonia, third-party APIs or any
-        // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
-        // yet and stuff might break.
-        public static void Main(string[] args)
+        var loggerConfig = LoggingSetup.CreateLoggingConfiguration();
+        LogManager.Configuration = loggerConfig;
+        SentrySdk.Init(ApplicationSettings.ApplicationOptions.SentryDsn);
+
+        var logger = LogManager.GetCurrentClassLogger();
+        if (OperatingSystem.IsWindows())
         {
-            LoggingSetup.InitializeLogging(ApplicationSettings.ApplicationOptions.SentryDsn, new());
-            if (OperatingSystem.IsWindows())
-            {
-                Logging.Logger.Debug("Operating system is windows.");
-                SquirrelAwareApp.HandleEvents(onInitialInstall: OnInitialInstall, onAppUninstall: OnAppUninstall, onEveryRun: OnEveryRun);
-            }
-
-            Logging.Logger.Info("------------------------------");
-            Logging.Logger.Info("Starting application...");
-            var culture = AppConstants.DefaultCultureDetails.CultureInfo;
-            Thread.CurrentThread.CurrentCulture = culture;
-            Thread.CurrentThread.CurrentUICulture = culture;
-
-            try
-            {
-                BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
-            }
-            catch (Exception e)
-            {
-                Logging.Logger.Fatal(e, "Encountered a critical error that will end the application.");
-                throw;
-            }
-
-            Logging.Logger.Info("Application is shutting down.");
-            Logging.Logger.Info("------------------------------\n");
+            logger.Debug("Operating system is windows.");
+            SquirrelAwareApp.HandleEvents(onInitialInstall: OnInitialInstall, onAppUninstall: OnAppUninstall, onEveryRun: OnEveryRun);
         }
 
-        private static void OnEveryRun(SemanticVersion version, IAppTools tools, bool firstRun)
+        logger.Info("------------------------------");
+        logger.Info("Starting application...");
+        var culture = AppConstants.DefaultCultureDetails.CultureInfo;
+        Thread.CurrentThread.CurrentCulture = culture;
+        Thread.CurrentThread.CurrentUICulture = culture;
+
+        try
         {
-            tools.SetProcessAppUserModelId();
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        }
+        catch (Exception e)
+        {
+            logger.Fatal(e, "Encountered a critical error that will end the application.");
+            throw;
         }
 
-        // Avalonia configuration, don't remove; also used by visual designer.
-        public static AppBuilder BuildAvaloniaApp()
-            => AppBuilder.Configure<App>()
-                .UsePlatformDetect()
-                .LogToTrace()
-                .UseSkia()
-                .UseUpdatedReactiveUI();
+        logger.Info("Application is shutting down.");
+        logger.Info("------------------------------\n");
+    }
 
-        [SupportedOSPlatform("windows")]
-        private static void OnAppUninstall(SemanticVersion version, IAppTools tools)
+    private static void OnEveryRun(SemanticVersion version, IAppTools tools, bool firstRun)
+    {
+        tools.SetProcessAppUserModelId();
+    }
+
+    // Avalonia configuration, don't remove; also used by visual designer.
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace()
+            .UseSkia()
+            .UseUpdatedReactiveUI();
+
+    [SupportedOSPlatform("windows")]
+    private static void OnAppUninstall(SemanticVersion version, IAppTools tools)
+    {
+        LogManager.GetCurrentClassLogger().Info("App is uninstalling...");
+        tools.RemoveShortcutForThisExe();
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void OnInitialInstall(SemanticVersion version, IAppTools tools)
+    {
+        var logger = LogManager.GetCurrentClassLogger();
+        logger.Info("App has been installed, creating shortcuts...");
+        try
         {
-            Logging.Logger.Info("App is uninstalling...");
-            tools.RemoveShortcutForThisExe();
+            tools.CreateShortcutForThisExe();
+            logger.Info("Shortcuts have been created.");
         }
-
-        [SupportedOSPlatform("windows")]
-        private static void OnInitialInstall(SemanticVersion version, IAppTools tools)
+        catch (Exception e)
         {
-            Logging.Logger.Info("App has been installed, creating shortcuts...");
-            try
-            {
-                tools.CreateShortcutForThisExe();
-                Logging.Logger.Info("Shortcuts have been created.");
-            }
-            catch (Exception e)
-            {
-                Logging.Logger.Error(e);
-                throw;
-            }
+            logger.Error(e);
+            throw;
         }
     }
 }

--- a/WoWsShipBuilder.UI/Settings/AppSettingsHelper.cs
+++ b/WoWsShipBuilder.UI/Settings/AppSettingsHelper.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 using Splat;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.DataProvider;
@@ -31,11 +32,11 @@ public static class AppSettingsHelper
     {
         if (File.Exists(SettingFile))
         {
-            Logging.Logger.Info("Trying to load settings from settings file...");
+            Logging.Logger.LogInformation("Trying to load settings from settings file...");
             var settings = Locator.Current.GetRequiredService<IDataService>().Load<AppSettings>(SettingFile);
             if (settings == null)
             {
-                Logging.Logger.Error("Unable to parse local settings file. Creating empty settings instance.");
+                Logging.Logger.LogError("Unable to parse local settings file. Creating empty settings instance");
                 settings = new();
             }
 
@@ -43,12 +44,12 @@ public static class AppSettingsHelper
         }
         else
         {
-            Logging.Logger.Info("No settings file found, creating new settings...");
+            Logging.Logger.LogInformation("No settings file found, creating new settings...");
             Settings.UpdateFromSettings(new());
         }
 
         AppData.IsInitialized = true;
-        Logging.Logger.Info("Settings initialized.");
+        Logging.Logger.LogInformation("Settings initialized");
         UpdateThreadCulture(Settings.SelectedLanguage.CultureInfo);
     }
 

--- a/WoWsShipBuilder.UI/Translations/LocalizeConverter.cs
+++ b/WoWsShipBuilder.UI/Translations/LocalizeConverter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Text;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.Localization;
 using WoWsShipBuilder.UI.Settings;
@@ -42,7 +43,7 @@ namespace WoWsShipBuilder.UI.Translations
                     // TODO: fix properly by handling Unit property in TooltipDataElement generation
                     if (localization == null && !string.IsNullOrWhiteSpace(localizerKey))
                     {
-                        Logging.Logger.Warn($"Missing localization for key {localizerKey}.");
+                        Logging.Logger.LogWarning("Missing localization for key {LocalizerKey}", localizerKey);
                         Debug.WriteLine(localizerKey);
                     }
 

--- a/WoWsShipBuilder.UI/UserControls/ShipStatsControl.axaml.cs
+++ b/WoWsShipBuilder.UI/UserControls/ShipStatsControl.axaml.cs
@@ -2,9 +2,12 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.VisualTree;
+using Microsoft.Extensions.Logging;
+using Splat;
 using WoWsShipBuilder.Core.DataContainers;
 using WoWsShipBuilder.Core.DataProvider;
 using WoWsShipBuilder.DataStructures.Projectile;
+using WoWsShipBuilder.UI.Extensions;
 using WoWsShipBuilder.UI.ViewModels.DispersionPlot;
 using WoWsShipBuilder.UI.Views;
 using WoWsShipBuilder.ViewModels.ShipVm;
@@ -63,7 +66,7 @@ namespace WoWsShipBuilder.UI.UserControls
             var textBlock = (TextBlock)sender;
             string shellIndex = ((ShellDataContainer)textBlock.DataContext!).Name;
             var shell = AppData.FindProjectile<ArtilleryShell>(shellIndex);
-            win.DataContext = new DispersionGraphViewModel(win, mainBattery.DispersionData, (double)mainBattery.Range * 1000, dc.CurrentShipStats.Index, shell, tab, mainBattery.Sigma);
+            win.DataContext = new DispersionGraphViewModel(Locator.Current.GetRequiredService<ILogger<DispersionGraphViewModel>>(), win, mainBattery.DispersionData, (double)mainBattery.Range * 1000, dc.CurrentShipStats.Index, shell, tab, mainBattery.Sigma);
             win.Show((Window)this.GetVisualRoot());
             e.Handled = true;
         }

--- a/WoWsShipBuilder.UI/Utilities/ClipboardHelper.cs
+++ b/WoWsShipBuilder.UI/Utilities/ClipboardHelper.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Avalonia.Media.Imaging;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.Core;
 
 namespace WoWsShipBuilder.UI.Utilities
@@ -23,7 +24,7 @@ namespace WoWsShipBuilder.UI.Utilities
             }
             catch (Exception e)
             {
-                Logging.Logger.Error(e, "Error while writing image to clipboard.");
+                Logging.Logger.LogError(e, "Error while writing image to clipboard");
             }
         }
 
@@ -57,7 +58,7 @@ namespace WoWsShipBuilder.UI.Utilities
             }
             catch (Exception e)
             {
-                Logging.Logger.Error(e, "Error while accessing clipboard.");
+                Logging.Logger.LogError(e, "Error while accessing clipboard");
             }
         }
 

--- a/WoWsShipBuilder.UI/Utilities/WindowScalingHelper.cs
+++ b/WoWsShipBuilder.UI/Utilities/WindowScalingHelper.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Platform;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.Core;
-using WoWsShipBuilder.UI.Extensions;
 
 namespace WoWsShipBuilder.UI.Utilities
 {
@@ -49,13 +49,13 @@ namespace WoWsShipBuilder.UI.Utilities
                 shouldScale = true;
             }
 
-            Logging.Logger.Info("Checked scaling for window {} with result {} and factor {}.", currentWindow.Title, shouldScale, scalingFactor);
+            Logging.Logger.LogInformation("Checked scaling for window {Title} with result {ShouldScale} and factor {ScalingFactor}", currentWindow.Title, shouldScale, scalingFactor);
             return new(shouldScale, scalingFactor);
         }
 
         private static void RepositionWindow(Window window, double scaling, Screen currentScreen)
         {
-            Logging.Logger.Info("Rearranging window position and scaling window size.");
+            Logging.Logger.LogInformation("Rearranging window position and scaling window size");
             var newWidth = window.Width * scaling;
             var newHeight = window.Height * scaling;
             var pixelSize = PixelSize.FromSize(new(newWidth, newHeight), currentScreen.PixelDensity);
@@ -75,7 +75,7 @@ namespace WoWsShipBuilder.UI.Utilities
             }
             else
             {
-                Logging.Logger.Warn("Window resizing was triggered on a window that is not scalable.");
+                Logging.Logger.LogWarning("Window resizing was triggered on a window that is not scalable");
             }
         }
     }

--- a/WoWsShipBuilder.UI/ViewModels/Dialog/BuildImportViewModel.cs
+++ b/WoWsShipBuilder.UI/ViewModels/Dialog/BuildImportViewModel.cs
@@ -2,6 +2,7 @@
 using System.IO.Abstractions;
 using System.Reactive;
 using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.Builds;
@@ -42,7 +43,7 @@ namespace WoWsShipBuilder.UI.ViewModels.Dialog
                 {
                     if (args.ErrorContext.Error is JsonReaderException)
                     {
-                        Logging.Logger.Info("Tried to load an invalid build string from an image file. Message: {}", args.ErrorContext.Error.Message);
+                        Logging.Logger.LogInformation("Tried to load an invalid build string from an image file. Message: {}", args.ErrorContext.Error.Message);
                         args.ErrorContext.Handled = true;
                     }
                 },

--- a/WoWsShipBuilder.UI/ViewModels/ScreenshotContainerViewModel.cs
+++ b/WoWsShipBuilder.UI/ViewModels/ScreenshotContainerViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media.Imaging;
+using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.Builds;
 using WoWsShipBuilder.Core.DataProvider;
 using WoWsShipBuilder.DataStructures;
@@ -75,7 +76,7 @@ namespace WoWsShipBuilder.UI.ViewModels
                 CaptainSkillSelectorViewModel = new(ship.ShipClass, CaptainSkillSelectorViewModel.LoadParams(ship.ShipNation), true),
                 SignalSelectorViewModel = new(),
                 UpgradePanelViewModel = new UpgradePanelViewModel(ship, AppData.ModernizationCache),
-                ConsumableViewModel = ConsumableViewModel.Create(ship, new List<string>()),
+                ConsumableViewModel = ConsumableViewModel.Create(ship, new List<string>(), Logging.LoggerFactory),
             };
             vm.LoadBuilds(build);
             return vm;

--- a/WoWsShipBuilder.UI/ViewModels/ShipVm/ShipWindowViewModel.cs
+++ b/WoWsShipBuilder.UI/ViewModels/ShipVm/ShipWindowViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
-using WoWsShipBuilder.Core;
+using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.Core.Builds;
 using WoWsShipBuilder.Core.Data;
 using WoWsShipBuilder.Core.DataProvider;
@@ -22,17 +22,20 @@ namespace WoWsShipBuilder.UI.ViewModels.ShipVm
 
         private readonly ILocalizer localizer;
 
-        public ShipWindowViewModel(INavigationService navigationService, IClipboardService clipboardService, ILocalizer localizer, ShipViewModelParams viewModelParams)
-            : base(navigationService, localizer, viewModelParams)
+        private readonly ILogger<ShipWindowViewModel> logger;
+
+        public ShipWindowViewModel(INavigationService navigationService, IClipboardService clipboardService, ILocalizer localizer, ILogger<ShipWindowViewModel> logger, ShipViewModelParams viewModelParams)
+            : base(navigationService, localizer, logger, viewModelParams)
         {
             this.clipboardService = clipboardService;
             this.localizer = localizer;
             screenshotRenderService = new();
+            this.logger = logger;
         }
 
         public async void OpenSaveBuild()
         {
-            Logging.Logger.Info("Saving build");
+            logger.LogInformation("Saving build");
             string shipName = localizer.GetGameLocalization(CurrentShipIndex).Localization;
             var dialogResult = await BuildCreationInteraction.Handle(new(AppSettingsHelper.Settings, shipName, CurrentBuildName)) ?? BuildCreationResult.Canceled;
             if (!dialogResult.Save)
@@ -44,7 +47,7 @@ namespace WoWsShipBuilder.UI.ViewModels.ShipVm
             var oldBuild = AppData.Builds.FirstOrDefault(existingBuild => existingBuild.BuildName.Equals(currentBuild.BuildName) && existingBuild.ShipIndex.Equals(currentBuild.ShipIndex));
             if (oldBuild != null)
             {
-                Logging.Logger.Info("Removing old build with identical name from list of saved builds to replace with new build.");
+                logger.LogInformation("Removing old build with identical name from list of saved builds to replace with new build");
                 AppData.Builds.Remove(oldBuild);
             }
 

--- a/WoWsShipBuilder.UI/ViewModels/StartMenuViewModel.cs
+++ b/WoWsShipBuilder.UI/ViewModels/StartMenuViewModel.cs
@@ -3,7 +3,6 @@ using System.Reactive.Linq;
 using WoWsShipBuilder.Core.Localization;
 using WoWsShipBuilder.Core.Services;
 using WoWsShipBuilder.UI.Services;
-using WoWsShipBuilder.UI.Settings;
 using WoWsShipBuilder.UI.ViewModels.Dialog;
 using WoWsShipBuilder.ViewModels.Helper;
 using WoWsShipBuilder.ViewModels.Other;
@@ -15,7 +14,7 @@ namespace WoWsShipBuilder.UI.ViewModels
         private readonly IFileSystem fileSystem;
 
         public StartMenuViewModel(IFileSystem fileSystem, INavigationService navigationService, IClipboardService clipboardService, IAppDataService appDataService, IUserDataService userDataService, ILocalizer localizer, AppNotificationService notificationService)
-            : base(navigationService, clipboardService, appDataService, userDataService, localizer, AppSettingsHelper.Settings)
+            : base(navigationService, clipboardService, appDataService, userDataService, localizer)
         {
             this.fileSystem = fileSystem;
             NotificationService = notificationService;

--- a/WoWsShipBuilder.UI/Views/DownloadWindow.axaml.cs
+++ b/WoWsShipBuilder.UI/Views/DownloadWindow.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
+using Microsoft.Extensions.Logging;
 using Splat;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.Localization;
@@ -45,7 +46,7 @@ namespace WoWsShipBuilder.UI.Views
                 }
                 catch (Exception e)
                 {
-                    Logging.Logger.Error(e, "Encountered unexpected error during data download.");
+                    Logging.Logger.LogError(e, "Encountered unexpected error during data download");
                     await Dispatcher.UIThread.InvokeAsync(async () =>
                         await MessageBox.Show(
                             this,

--- a/WoWsShipBuilder.UI/Views/SplashScreen.axaml.cs
+++ b/WoWsShipBuilder.UI/Views/SplashScreen.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 using Avalonia.Threading;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 using Splat;
 using WoWsShipBuilder.Core;
@@ -37,7 +38,7 @@ namespace WoWsShipBuilder.UI.Views
                     }
                     catch (Exception e)
                     {
-                        Logging.Logger.Error(e, "Encountered unexpected error during data download.");
+                        Logging.Logger.LogError(e, "Encountered unexpected error during data download");
                         await Dispatcher.UIThread.InvokeAsync(async () =>
                             await MessageBox.Show(
                                 this,

--- a/WoWsShipBuilder.UI/Views/StartMenuWindow.axaml.cs
+++ b/WoWsShipBuilder.UI/Views/StartMenuWindow.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 using Squirrel;
 using WoWsShipBuilder.Core;
@@ -100,7 +101,7 @@ namespace WoWsShipBuilder.UI.Views
             var result = await UpdateHelpers.ShowUpdateRestartDialog(this);
             if (result == MessageBox.MessageBoxResult.Yes)
             {
-                Logging.Logger.Info("User decided to restart after update.");
+                Logging.Logger.LogInformation("User decided to restart after update");
                 if (OperatingSystem.IsWindows())
                 {
                     UpdateManager.RestartApp();

--- a/WoWsShipBuilder.UI/WoWsShipBuilder.UI.csproj
+++ b/WoWsShipBuilder.UI/WoWsShipBuilder.UI.csproj
@@ -47,6 +47,7 @@
         <None Remove="Assets\Question_Full.png" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Avalonia" Version="0.10.18" />
         <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
         <PackageReference Include="Avalonia.Diagnostics" Version="0.10.18" />
@@ -54,6 +55,7 @@
         <PackageReference Include="Clowd.Squirrel" Version="2.9.42" />
         <PackageReference Include="Deadpikle.AvaloniaProgressRing" Version="0.9.7" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="NLog.Extensions.Logging" Version="5.2.3" />
         <PackageReference Include="OxyPlot.Avalonia" Version="2.1.0-Preview1" />
         <PackageReference Include="Roslyn.System.IO.Abstractions.Analyzers" Version="12.2.19">
             <PrivateAssets>all</PrivateAssets>

--- a/WoWsShipBuilder.ViewModels/Helper/BuildImportViewModelBase.cs
+++ b/WoWsShipBuilder.ViewModels/Helper/BuildImportViewModelBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reactive;
 using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.Builds;
@@ -40,15 +41,15 @@ public partial class BuildImportViewModelBase : ViewModelBase
     private async Task Import()
     {
         Build build;
-        Logging.Logger.Info("Trying to import build string: {0}", BuildString);
+        Logging.Logger.LogInformation("Trying to import build string: {BuildString}", BuildString);
         try
         {
             build = Build.CreateBuildFromString(BuildString!);
-            Logging.Logger.Info("Build correctly created");
+            Logging.Logger.LogInformation("Build correctly created");
         }
         catch (Exception e)
         {
-            Logging.Logger.Warn(e, "Error in creating the build.");
+            Logging.Logger.LogWarning(e, "Error in creating the build");
             await MessageBoxInteraction.Handle(("The Build string is not in the correct format.", "Invalid string."));
             return;
         }
@@ -60,7 +61,7 @@ public partial class BuildImportViewModelBase : ViewModelBase
     {
         if (!ImportOnly)
         {
-            Logging.Logger.Info("Adding build to saved ones.");
+            Logging.Logger.LogInformation("Adding build to saved ones");
             AppData.Builds.Insert(0, build);
         }
 

--- a/WoWsShipBuilder.ViewModels/Other/SettingsWindowViewModelBase.cs
+++ b/WoWsShipBuilder.ViewModels/Other/SettingsWindowViewModelBase.cs
@@ -7,6 +7,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.DataProvider;
@@ -52,7 +53,7 @@ namespace WoWsShipBuilder.ViewModels.Other
 
         public SettingsWindowViewModelBase(IClipboardService clipboardService, IAppDataService appDataService, AppSettings appSettings)
         {
-            Logging.Logger.Info("Creating setting window view model");
+            Logging.Logger.LogInformation("Creating setting window view model");
             this.clipboardService = clipboardService;
             this.appSettings = appSettings;
             AppDataService = appDataService;
@@ -82,7 +83,7 @@ namespace WoWsShipBuilder.ViewModels.Other
         {
             if (AppData.DataVersion is null)
             {
-                Logging.Logger.Info("AppData.DataVersion is null, reading from VersionInfo.");
+                Logging.Logger.LogInformation("AppData.DataVersion is null, reading from VersionInfo");
 
                 var localVersionInfo = await appDataService.GetCurrentVersionInfo(appSettings.SelectedServerType);
                 if (localVersionInfo?.CurrentVersion?.MainVersion != null)
@@ -193,7 +194,7 @@ namespace WoWsShipBuilder.ViewModels.Other
 
         public async void Save()
         {
-            Logging.Logger.Info("Saving settings");
+            Logging.Logger.LogInformation("Saving settings");
             bool serverChanged = appSettings.SelectedServerType != Enum.Parse<ServerType>(SelectedServer);
             bool pathChanged = appSettings.CustomDataPath != null && !IsCustomPathEnabled;
             bool imagePathChanged = IsCustomBuildImagePathEnabled ? !(CustomBuildImagePath?.Equals(appSettings.CustomImagePath) ?? false) : appSettings.CustomImagePath != null;

--- a/WoWsShipBuilder.ViewModels/Other/ShipBuildViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/Other/ShipBuildViewModel.cs
@@ -1,4 +1,5 @@
-﻿using WoWsShipBuilder.Core.Builds;
+﻿using WoWsShipBuilder.Core;
+using WoWsShipBuilder.Core.Builds;
 using WoWsShipBuilder.Core.Data;
 using WoWsShipBuilder.Core.DataContainers;
 using WoWsShipBuilder.Core.DataProvider;
@@ -47,7 +48,7 @@ public partial class ShipBuildViewModel : ViewModelBase
             CaptainSkillSelectorViewModel = new(ship.ShipClass, CaptainSkillSelectorViewModel.LoadParams(ship.ShipNation)),
             ShipModuleViewModel = new(ship.ShipUpgradeInfo),
             UpgradePanelViewModel = new(ship, AppData.ModernizationCache),
-            ConsumableViewModel = ConsumableViewModel.Create(ship, new List<string>()),
+            ConsumableViewModel = ConsumableViewModel.Create(ship, new List<string>(), Logging.LoggerFactory),
             SpecialAbilityActive = shipBuildContainer.SpecialAbilityActive,
         };
 

--- a/WoWsShipBuilder.ViewModels/Other/StartMenuViewModelBase.cs
+++ b/WoWsShipBuilder.ViewModels/Other/StartMenuViewModelBase.cs
@@ -2,14 +2,13 @@ using System;
 using System.Collections.ObjectModel;
 using System.Reactive;
 using System.Reactive.Linq;
-using Newtonsoft.Json;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.Builds;
 using WoWsShipBuilder.Core.DataProvider;
 using WoWsShipBuilder.Core.Localization;
 using WoWsShipBuilder.Core.Services;
-using WoWsShipBuilder.Core.Settings;
 using WoWsShipBuilder.ViewModels.Base;
 using WoWsShipBuilder.ViewModels.Helper;
 
@@ -25,17 +24,14 @@ namespace WoWsShipBuilder.ViewModels.Other
 
         private readonly ILocalizer localizer;
 
-        protected readonly AppSettings AppSettings;
-
         private int? selectedBuild;
 
-        public StartMenuViewModelBase(INavigationService navigationService, IClipboardService clipboardService, IAppDataService appDataService, IUserDataService userDataService, ILocalizer localizer, AppSettings appSettings)
+        public StartMenuViewModelBase(INavigationService navigationService, IClipboardService clipboardService, IAppDataService appDataService, IUserDataService userDataService, ILocalizer localizer)
         {
             NavigationService = navigationService;
             ClipboardService = clipboardService;
             AppDataService = appDataService;
             this.localizer = localizer;
-            AppSettings = appSettings;
             if (!AppData.Builds.Any())
             {
                 userDataService.LoadBuilds();
@@ -81,7 +77,7 @@ namespace WoWsShipBuilder.ViewModels.Other
             var result = (await SelectShipInteraction.Handle(dc))?.FirstOrDefault();
             if (result != null)
             {
-                Logging.Logger.Info("Selected ship with index {}", result.Index);
+                Logging.Logger.LogInformation("Selected ship with index {}", result.Index);
                 try
                 {
                     var ship = AppData.FindShipFromSummary(result);
@@ -89,7 +85,7 @@ namespace WoWsShipBuilder.ViewModels.Other
                 }
                 catch (Exception e)
                 {
-                    Logging.Logger.Error(e, "Error during the loading of the local json files");
+                    Logging.Logger.LogError(e, "Error during the loading of the local json files");
                     await MessageBoxInteraction.Handle((Translation.MessageBox_Error, Translation.MessageBox_LoadingError, true));
                 }
             }
@@ -116,7 +112,7 @@ namespace WoWsShipBuilder.ViewModels.Other
                 }
             }
 
-            Logging.Logger.Info("Loading build {0}", JsonConvert.SerializeObject(build));
+            Logging.Logger.LogInformation("Loading build {@Build}", build);
 
             var summary = AppData.ShipSummaryList.SingleOrDefault(ship => ship.Index.Equals(build.ShipIndex));
             if (summary is null)
@@ -132,7 +128,7 @@ namespace WoWsShipBuilder.ViewModels.Other
             }
             catch (Exception e)
             {
-                Logging.Logger.Error(e, "Error during the loading of the local json files");
+                Logging.Logger.LogError(e, "Error during the loading of the local json files");
                 await MessageBoxInteraction.Handle((Translation.MessageBox_Error, Translation.MessageBox_LoadingError, true));
             }
         }

--- a/WoWsShipBuilder.ViewModels/ShipVm/CaptainSkillSelectorViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/CaptainSkillSelectorViewModel.cs
@@ -225,13 +225,13 @@ public partial class CaptainSkillSelectorViewModel : ViewModelBase
     /// <returns>A dictionary containing the skill for the class from the captain.</returns>
     private Dictionary<string, SkillItemViewModel> ConvertSkillToViewModel(ShipClass shipClass, Captain? captain)
     {
-        logger.LogInformation("Getting skill for class {ShipClass} from captain {CaptainName}", shipClass.ToString(), captain!.Name);
+        logger.LogDebug("Getting skill for class {ShipClass} from captain {CaptainName}", shipClass.ToString(), captain!.Name);
         var skills = captain.Skills;
 
         var filteredSkills = skills.Where(x => x.Value.LearnableOn.Contains(shipClass)).ToList();
 
         var dictionary = filteredSkills.ToDictionary(x => x.Key, x => new SkillItemViewModel(x.Value, this, shipClass, canAddSkillCache, canRemoveSkillCache));
-        logger.LogInformation("Found {SkillCount} skills", dictionary.Count);
+        logger.LogDebug("Found {SkillCount} skills", dictionary.Count);
         return dictionary;
     }
 
@@ -262,6 +262,7 @@ public partial class CaptainSkillSelectorViewModel : ViewModelBase
     {
         if (SkillOrderList.Contains(skill))
         {
+            logger.LogDebug("Adding skill {Skill} to skill order list", skill.SkillNumber);
             SkillOrderList.Remove(skill);
             ReorderSkillList();
             int pointCost = skill.Tiers.First(x => x.ShipClass == currentClass).Tier + 1;
@@ -281,6 +282,7 @@ public partial class CaptainSkillSelectorViewModel : ViewModelBase
         }
         else
         {
+            logger.LogDebug("Removing skill {Skill} from skill order list", skill.SkillNumber);
             SkillOrderList.Add(skill);
             var pointCost = skill.Tiers.First(x => x.ShipClass == currentClass).Tier + 1;
             AssignedPoints += pointCost;
@@ -331,7 +333,7 @@ public partial class CaptainSkillSelectorViewModel : ViewModelBase
             return;
         }
 
-        logger.LogInformation("Reordering skills");
+        logger.LogDebug("Reordering skills");
 
         // AvaloniaList is missing one of the extension methods, so we copy the list to a normal one,
         var groups = SkillOrderList.GroupBy(skill => skill.Tiers.First(x => x.ShipClass == currentClass).Tier)
@@ -409,7 +411,7 @@ public partial class CaptainSkillSelectorViewModel : ViewModelBase
             }
         }
 
-        logger.LogInformation("Finished reordering skills");
+        logger.LogDebug("Finished reordering skills");
     }
 
     /// <summary>

--- a/WoWsShipBuilder.ViewModels/ShipVm/CaptainSkillSelectorViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/CaptainSkillSelectorViewModel.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Specialized;
 using System.Reactive.Linq;
-using NLog;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.DataProvider;
@@ -23,7 +23,7 @@ public partial class CaptainSkillSelectorViewModel : ViewModelBase
 
     private readonly ShipClass currentClass;
 
-    private readonly Logger logger;
+    private readonly ILogger<CaptainSkillSelectorViewModel> logger;
 
     private readonly Dictionary<int, bool> canAddSkillCache = new();
 
@@ -36,7 +36,7 @@ public partial class CaptainSkillSelectorViewModel : ViewModelBase
 
     public CaptainSkillSelectorViewModel(ShipClass shipClass, (Captain defaultCaptain, Dictionary<string, Captain>? captainList) vmParams, bool screenshotMode = false)
     {
-        logger = Logging.GetLogger("CaptainSkillVM");
+        logger = Logging.LoggerFactory.CreateLogger<CaptainSkillSelectorViewModel>();
         ScreenshotMode = screenshotMode;
         currentClass = shipClass;
 
@@ -225,13 +225,13 @@ public partial class CaptainSkillSelectorViewModel : ViewModelBase
     /// <returns>A dictionary containing the skill for the class from the captain.</returns>
     private Dictionary<string, SkillItemViewModel> ConvertSkillToViewModel(ShipClass shipClass, Captain? captain)
     {
-        logger.Info("Getting skill for class {0} from captain {1}", shipClass.ToString(), captain!.Name);
+        logger.LogInformation("Getting skill for class {ShipClass} from captain {CaptainName}", shipClass.ToString(), captain!.Name);
         var skills = captain.Skills;
 
         var filteredSkills = skills.Where(x => x.Value.LearnableOn.Contains(shipClass)).ToList();
 
         var dictionary = filteredSkills.ToDictionary(x => x.Key, x => new SkillItemViewModel(x.Value, this, shipClass, canAddSkillCache, canRemoveSkillCache));
-        logger.Info("Found {0} skills", dictionary.Count);
+        logger.LogInformation("Found {SkillCount} skills", dictionary.Count);
         return dictionary;
     }
 
@@ -331,7 +331,7 @@ public partial class CaptainSkillSelectorViewModel : ViewModelBase
             return;
         }
 
-        logger.Info("Reordering skills");
+        logger.LogInformation("Reordering skills");
 
         // AvaloniaList is missing one of the extension methods, so we copy the list to a normal one,
         var groups = SkillOrderList.GroupBy(skill => skill.Tiers.First(x => x.ShipClass == currentClass).Tier)
@@ -409,7 +409,7 @@ public partial class CaptainSkillSelectorViewModel : ViewModelBase
             }
         }
 
-        logger.Info("Finished reordering skills");
+        logger.LogInformation("Finished reordering skills");
     }
 
     /// <summary>

--- a/WoWsShipBuilder.ViewModels/ShipVm/ConsumableSlotViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/ConsumableSlotViewModel.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ReactiveUI;
 using WoWsShipBuilder.Core.DataContainers;
 using WoWsShipBuilder.DataStructures.Ship;
@@ -10,6 +12,7 @@ public class ConsumableSlotViewModel : ViewModelBase
 {
     private readonly Action<int, bool>? activationChangeHandler;
     private readonly List<ShipConsumable> shipConsumables;
+    private readonly ILogger<ConsumableSlotViewModel> logger;
 
     private bool consumableActivated;
 
@@ -18,13 +21,14 @@ public class ConsumableSlotViewModel : ViewModelBase
     private int selectedIndex;
 
     public ConsumableSlotViewModel()
-        : this(new List<ShipConsumable>(), null)
+        : this(new List<ShipConsumable>(), null, NullLogger<ConsumableSlotViewModel>.Instance)
     {
     }
 
-    private ConsumableSlotViewModel(IEnumerable<ShipConsumable> shipConsumables, Action<int, bool>? activationChangeHandler)
+    private ConsumableSlotViewModel(IEnumerable<ShipConsumable> shipConsumables, Action<int, bool>? activationChangeHandler, ILogger<ConsumableSlotViewModel> logger)
     {
         this.activationChangeHandler = activationChangeHandler;
+        this.logger = logger;
         this.shipConsumables = new(shipConsumables);
         Slot = this.shipConsumables.First().Slot;
     }
@@ -48,6 +52,7 @@ public class ConsumableSlotViewModel : ViewModelBase
         {
             this.RaiseAndSetIfChanged(ref selectedIndex, value);
             this.RaisePropertyChanged(nameof(SelectedConsumable));
+            logger.LogDebug("Selected consumable changed to index {Index}", value);
             ConsumableActivated = false;
         }
     }
@@ -64,9 +69,9 @@ public class ConsumableSlotViewModel : ViewModelBase
 
     public ConsumableDataContainer SelectedConsumable => ConsumableData[SelectedIndex];
 
-    public static ConsumableSlotViewModel Create(IEnumerable<ShipConsumable> shipConsumables, Action<int, bool>? activationChangeHandler = null)
+    public static ConsumableSlotViewModel Create(IEnumerable<ShipConsumable> shipConsumables, ILoggerFactory loggerFactory, Action<int, bool>? activationChangeHandler = null)
     {
-        var vm = new ConsumableSlotViewModel(shipConsumables, activationChangeHandler);
+        var vm = new ConsumableSlotViewModel(shipConsumables, activationChangeHandler, loggerFactory.CreateLogger<ConsumableSlotViewModel>());
         vm.UpdateDataContainers(new(), 0);
         return vm;
     }

--- a/WoWsShipBuilder.ViewModels/ShipVm/ShipViewModelBase.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/ShipViewModelBase.cs
@@ -7,6 +7,7 @@ using System.Windows.Input;
 using DynamicData.Binding;
 using Microsoft.Extensions.Logging;
 using ReactiveUI;
+using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.Builds;
 using WoWsShipBuilder.Core.Data;
 using WoWsShipBuilder.Core.DataContainers;
@@ -89,7 +90,7 @@ public partial class ShipViewModelBase : ViewModelBase
 
     public async void ResetBuild()
     {
-        logger.LogInformation("Resetting build");
+        logger.LogDebug("Resetting build");
         await LoadNewShip(AppData.ShipSummaryList!.First(summary => summary.Index.Equals(CurrentShipIndex)));
     }
 
@@ -113,12 +114,12 @@ public partial class ShipViewModelBase : ViewModelBase
 
     public async void NewShipSelection()
     {
-        logger.LogInformation("Selecting new ship");
+        logger.LogDebug("Selecting new ship");
 
         var result = (await SelectNewShipInteraction.Handle(new(false, ShipSelectionWindowViewModel.LoadParams(localizer))))?.FirstOrDefault();
         if (result != null)
         {
-            logger.LogInformation("New ship selected: {Index}", result.Index);
+            logger.LogDebug("New ship selected: {Index}", result.Index);
             await LoadNewShip(result);
         }
     }
@@ -153,7 +154,7 @@ public partial class ShipViewModelBase : ViewModelBase
     private async Task InitializeData(Ship ship, string? previousIndex, List<string>? nextShipsIndexes, Build? build = null)
     {
         logger.LogInformation("Loading data for ship {Index}", ship.Index);
-        logger.LogInformation("Build is null: {BuildIsNull}", build is null);
+        logger.LogDebug("Build is null: {BuildIsNull}", build is null);
 
         ShipDataContainer.ExpanderStateMapper.Clear();
 
@@ -161,21 +162,21 @@ public partial class ShipViewModelBase : ViewModelBase
         RawShipData = ship;
         EffectiveShipData = RawShipData;
 
-        logger.LogInformation("Initializing view models");
+        logger.LogDebug("Initializing view models");
 
         // Viewmodel inits
         SignalSelectorViewModel = new();
         CaptainSkillSelectorViewModel = new(RawShipData.ShipClass, CaptainSkillSelectorViewModel.LoadParams(ship.ShipNation));
         ShipModuleViewModel = new(RawShipData.ShipUpgradeInfo);
         UpgradePanelViewModel = new(RawShipData, AppData.ModernizationCache);
-        ConsumableViewModel = ConsumableViewModel.Create(RawShipData, new List<string>());
+        ConsumableViewModel = ConsumableViewModel.Create(RawShipData, new List<string>(), Logging.LoggerFactory);
 
         ShipStatsControlViewModel = new(EffectiveShipData);
         await ShipStatsControlViewModel.UpdateShipStats(ShipModuleViewModel.SelectedModules.ToList(), GenerateModifierList());
 
         if (build != null)
         {
-            logger.LogInformation("Loading build");
+            logger.LogDebug("Loading build");
             SignalSelectorViewModel.LoadBuild(build.Signals);
             CaptainSkillSelectorViewModel.LoadBuild(build.Skills, build.Captain);
             ShipModuleViewModel.LoadBuild(build.Modules);
@@ -237,7 +238,7 @@ public partial class ShipViewModelBase : ViewModelBase
                         var modifiers = GenerateModifierList();
                         if (ShipStatsControlViewModel != null)
                         {
-                            logger.LogInformation("Updating ship stats");
+                            logger.LogDebug("Updating ship stats");
                             await ShipStatsControlViewModel.UpdateShipStats(ShipModuleViewModel.SelectedModules.ToList(), modifiers);
                         }
                         var hp = ShipStatsControlViewModel!.CurrentShipStats!.SurvivabilityDataContainer.HitPoints;

--- a/WoWsShipBuilder.ViewModels/ShipVm/SignalSelectorViewModel.cs
+++ b/WoWsShipBuilder.ViewModels/ShipVm/SignalSelectorViewModel.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Reactive.Linq;
-using NLog;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.DataProvider;
@@ -11,11 +11,11 @@ namespace WoWsShipBuilder.ViewModels.ShipVm;
 
 public class SignalSelectorViewModel : ViewModelBase
 {
-    private readonly Logger logger;
+    private readonly ILogger<SignalSelectorViewModel> logger;
 
     public SignalSelectorViewModel()
     {
-        logger = Logging.GetLogger("SignalSelectorVM");
+        logger = Logging.LoggerFactory.CreateLogger<SignalSelectorViewModel>();
         SignalList = LoadSignalList();
 
         this.WhenAnyValue(x => x.SignalsNumber).Do(_ => UpdateCanToggleSkill()).Subscribe();
@@ -91,7 +91,7 @@ public class SignalSelectorViewModel : ViewModelBase
 
     public void LoadBuild(IReadOnlyList<string> initialSignalsNames)
     {
-        logger.Info("Initial signal configuration found {0}", string.Join(", ", initialSignalsNames));
+        logger.LogInformation("Initial signal configuration found {SignalNames}", string.Join(", ", initialSignalsNames));
         var list = SignalList.Select(x => x.Value.Signal).Where(signal => initialSignalsNames.Contains(signal.Index));
         SelectedSignals.AddRange(list);
         SignalsNumber = SelectedSignals.Count;

--- a/WoWsShipBuilder.Web.Test/ServerAwsClientTest.cs
+++ b/WoWsShipBuilder.Web.Test/ServerAwsClientTest.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
@@ -51,7 +52,7 @@ public class ServerAwsClientTest
 
         var cdnOptions = new CdnOptions { Host = "https://example.com"};
         IOptions<CdnOptions>? options = Options.Create(cdnOptions);
-        var client = new ServerAwsClient(new(messageHandlerMock.Object), options);
+        var client = new ServerAwsClient(new(messageHandlerMock.Object), options, NullLogger<ServerAwsClient>.Instance);
 
         var versionInfo = await client.DownloadVersionInfo(ServerType.Live);
         var files = versionInfo.Categories.SelectMany(category => category.Value.Select(file => (category.Key, file.FileName))).ToList();

--- a/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
+++ b/WoWsShipBuilder.Web/Components/ShipStatsContainer.razor
@@ -10,6 +10,7 @@
 @using WoWsShipBuilder.Web.Dialogs
 @using System.Net
 @using System.Diagnostics
+@using WoWsShipBuilder.Core
 @using WoWsShipBuilder.Core.Builds
 @using WoWsShipBuilder.Core.DataContainers
 @using WoWsShipBuilder.Core.Extensions
@@ -352,7 +353,7 @@
         var ship = AppData.FindShipFromSummary(shipSummary);
         var vmParams = new ShipViewModelParams(ship, shipSummary, build);
 
-        ShipViewModel vm = new(null!, localizer, vmParams);
+        ShipViewModel vm = new(null!, localizer, Logging.LoggerFactory.CreateLogger<ShipViewModel>(), vmParams);
         await vm.InitializeData(vmParams);
 
         return vm;

--- a/WoWsShipBuilder.Web/LinkShortening/FirebaseLinkShortener.cs
+++ b/WoWsShipBuilder.Web/LinkShortening/FirebaseLinkShortener.cs
@@ -35,7 +35,7 @@ public class FirebaseLinkShortener : ILinkShortener
 
     public async Task<ShorteningResult> CreateLinkForBuild(Build build)
     {
-        logger.LogInformation("Creating short link for build {}", build.Hash);
+        logger.LogInformation("Creating short link for build {BuildHash}", build.Hash);
         string buildString = build.CreateShortStringFromBuild();
         string encodedBuild = WebUtility.UrlEncode(buildString);
 
@@ -47,7 +47,7 @@ public class FirebaseLinkShortener : ILinkShortener
 
     public async Task<ShorteningResult> CreateShortLink(string link)
     {
-        logger.LogInformation("Creating short link for link {}", link);
+        logger.LogInformation("Creating short link for link {Link}", link);
         var request = new DynamicLinkRequest(new(options.UriPrefix, link), new(LinkSuffixType.SHORT));
         return await SendRequestAsync(request);
     }
@@ -70,9 +70,9 @@ public class FirebaseLinkShortener : ILinkShortener
 
     private async Task ResetLock()
     {
-        logger.LogDebug("Scheduling reset for semaphore permit. Available permits: {}", semaphore.CurrentCount);
+        logger.LogDebug("Scheduling reset for semaphore permit. Available permits: {PermitCount}", semaphore.CurrentCount);
         await Task.Delay(1000);
         semaphore.Release();
-        logger.LogDebug("Permit released. Available permits: {}", semaphore.CurrentCount);
+        logger.LogDebug("Permit released. Available permits: {PermitCount}", semaphore.CurrentCount);
     }
 }

--- a/WoWsShipBuilder.Web/Pages/ShipStats.razor
+++ b/WoWsShipBuilder.Web/Pages/ShipStats.razor
@@ -4,7 +4,6 @@
 @using DynamicData
 @using WoWsShipBuilder.Core.Builds
 @using WoWsShipBuilder.Core.Data
-@using WoWsShipBuilder.Core.DataContainers
 @using WoWsShipBuilder.Core.DataProvider
 @using WoWsShipBuilder.Web.Dialogs
 @using WoWsShipBuilder.Web.Services
@@ -13,6 +12,7 @@
 @inject ILocalizer Localizer
 @inject IDialogService DialogService
 @inject SessionStateCache SessionStateCache
+@inject ILogger<ShipStats> Logger
 
 <PageTitle>Ship stats</PageTitle>
 
@@ -74,27 +74,33 @@
         NavManager.TryGetQueryString("build", out shipBuildFromUrl);
         if (!string.IsNullOrEmpty(shipIndexesFromUrl))
         {
+            Logger.LogTrace("Ship indexes found in url");
             var buildContainers = SessionStateCache.GetAndResetBuildTransferContainers();
             List<ShipBuildContainer>? buildList;
             if (!string.IsNullOrWhiteSpace(shipBuildFromUrl))
             {
+                Logger.LogTrace("Build found in url, trying to parse it");
                 Build? build = null;
                 try
                 {
                     build = Build.CreateBuildFromString(shipBuildFromUrl);
+                    Logger.LogTrace("Build loaded from url");
                 }
                 catch (FormatException)
                 {
+                    Logger.LogTrace("Build could not be loaded from url because it was not in the correct format");
                 }
 
                 buildList = new() { ShipBuildContainer.CreateNew(AppData.ShipDictionary[shipIndexesFromUrl], build, null) };
             }
             else if (buildContainers is not null)
             {
+                Logger.LogTrace("Ship configurations found in session state cache, initializing from them");
                 buildList = buildContainers;
             }
             else
             {
+                Logger.LogTrace("Initializing without builds");
                 buildList = null;
             }
 
@@ -108,6 +114,7 @@
     {
         base.OnAfterRender(firstRender);
         if (!updateTab) return;
+        Logger.LogDebug("Tab update requested");
         mudTabs.ActivatePanel(selectedTabId, true);
         updateTab = false;
         StateHasChanged();
@@ -162,6 +169,7 @@
 
     private async Task OpenAddDialogAsync()
     {
+        Logger.LogTrace("Add ship dialog opened");
         var options = new DialogOptions
         {
             MaxWidth = MaxWidth.Large,
@@ -169,8 +177,10 @@
             DisableBackdropClick = false,
         };
         var result = await (await DialogService.ShowAsync<ShipSelectionDialog>("Add ships", options)).Result;
+        Logger.LogTrace("Result received from add ship dialog");
         if (!result.Canceled && result.Data is List<ShipBuildContainer> { Count: > 0 } newShips)
         {
+            Logger.LogTrace("Adding new ships");
             AddNewIndexes(new() { newShips.First().Ship.Index }, new() { newShips.First() });
             selectedTabId = shipContainers.Last().Id;
             AddNewIndexes(newShips.Skip(1).Select(x => x.Ship.Index).ToList(), newShips.Skip(1).ToList());
@@ -240,6 +250,7 @@
     private void UpdateUrl()
     {
         var shipsString = string.Join(",", shipContainers.Select(x => x.Ship.Index));
+        Logger.LogTrace("Updating URL with shipIndexes: {ShipIndexes}", shipsString);
         NavManager.NavigateTo($"/ship?shipIndexes={shipsString}");
     }
 

--- a/WoWsShipBuilder.Web/Program.cs
+++ b/WoWsShipBuilder.Web/Program.cs
@@ -6,6 +6,7 @@ using Prometheus;
 using ReactiveUI;
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
+using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.Services;
 using WoWsShipBuilder.Web.Extensions;
 using WoWsShipBuilder.Web.Services;
@@ -25,7 +26,7 @@ builder.Services.AddServerSideBlazor(options =>
 builder.ConfigureShipBuilderOptions();
 
 builder.Logging.ClearProviders();
-builder.Host.UseNLog(new() { RemoveLoggerFactoryFilter = false });
+builder.Host.UseNLog(new() { RemoveLoggerFactoryFilter = false, ParseMessageTemplates = true });
 SetupExtensions.ConfigureNlog(builder.Configuration.GetValue<bool>("DisableLoki"), builder.Environment.IsDevelopment());
 
 PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Blazor);
@@ -40,6 +41,7 @@ builder.Services.AddShipBuilderServerServices();
 
 var app = builder.Build();
 app.Services.UseMicrosoftDependencyResolver();
+Logging.Initialize(app.Services.GetRequiredService<ILoggerFactory>());
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/WoWsShipBuilder.Web/Services/ServerAppDataService.cs
+++ b/WoWsShipBuilder.Web/Services/ServerAppDataService.cs
@@ -39,7 +39,7 @@ public class ServerAppDataService : IAppDataService
 
     public async Task FetchData()
     {
-        logger.LogInformation("Starting to fetch data with server type {server}...", options.Server);
+        logger.LogInformation("Starting to fetch data with server type {Server}...", options.Server);
         const string undefinedMarker = "undefined";
         AppData.ResetCaches();
 
@@ -47,7 +47,7 @@ public class ServerAppDataService : IAppDataService
         if (onlineVersionInfo.CurrentVersion is not null)
         {
             AppData.DataVersion = onlineVersionInfo.CurrentVersion.MainVersion.ToString(3) + "#" + onlineVersionInfo.CurrentVersion.DataIteration;
-            logger.LogInformation("Found online version info with version {version}", AppData.DataVersion);
+            logger.LogInformation("Found online version info with version {Version}", AppData.DataVersion);
         }
         else
         {

--- a/WoWsShipBuilder.Web/Services/ServerAwsClient.cs
+++ b/WoWsShipBuilder.Web/Services/ServerAwsClient.cs
@@ -1,8 +1,6 @@
 ﻿using System.IO.Abstractions;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using NLog;
-using WoWsShipBuilder.Core;
 using WoWsShipBuilder.Core.DataProvider;
 using WoWsShipBuilder.Core.HttpClients;
 using WoWsShipBuilder.DataStructures.Versioning;
@@ -12,16 +10,17 @@ namespace WoWsShipBuilder.Web.Services;
 
 public class ServerAwsClient : IAwsClient
 {
-    private static readonly Logger Logger = Logging.GetLogger("AwsClient");
+    private readonly ILogger logger;
 
     private readonly HttpClient httpClient;
 
     private readonly CdnOptions options;
 
-    public ServerAwsClient(HttpClient httpClient, IOptions<CdnOptions> options)
+    public ServerAwsClient(HttpClient httpClient, IOptions<CdnOptions> options, ILogger<ServerAwsClient> logger)
     {
         this.httpClient = httpClient;
         this.options = options.Value;
+        this.logger = logger;
     }
 
     public async Task<VersionInfo> DownloadVersionInfo(ServerType serverType)
@@ -54,7 +53,7 @@ public class ServerAwsClient : IAwsClient
                 }
                 catch (HttpRequestException e)
                 {
-                    Logger.Warn(e, "Encountered an exception while downloading a file with uri {}.", uri);
+                    logger.LogWarning(e, "Encountered an exception while downloading a file with uri {Uri}", uri);
                 }
 
                 progress.Report(1);

--- a/WoWsShipBuilder.Web/ViewModels/ShipViewModel.cs
+++ b/WoWsShipBuilder.Web/ViewModels/ShipViewModel.cs
@@ -8,8 +8,8 @@ using WoWsShipBuilder.ViewModels.ShipVm;
 
 public class ShipViewModel : ShipViewModelBase
 {
-    public ShipViewModel(INavigationService navigationService, ILocalizer localizer, ShipViewModelParams viewModelParams)
-        : base(navigationService, localizer, viewModelParams)
+    public ShipViewModel(INavigationService navigationService, ILocalizer localizer, ILogger<ShipViewModel> logger, ShipViewModelParams viewModelParams)
+        : base(navigationService, localizer, logger, viewModelParams)
     {
     }
 }

--- a/WoWsShipBuilder.Web/WoWsShipBuilder.Web.csproj
+++ b/WoWsShipBuilder.Web/WoWsShipBuilder.Web.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="NLog.Targets.Loki" Version="1.4.6" />
-      <PackageReference Include="NLog.Web.AspNetCore" Version="5.2.1" />
+      <PackageReference Include="NLog.Web.AspNetCore" Version="5.2.3" />
       <PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
       <PackageReference Include="ReactiveUI.Blazor" Version="18.3.1" />
       <PackageReference Include="MudBlazor" Version="6.1.9" />


### PR DESCRIPTION
Use MS Logging interfaces and abstractions instead of NLog to reduce coupling introduced by the direct NLog dependency.

Behind the abstractions, NLog is still used as logging provider but core no longer needs to know about NLog.

resolves #187