### PR TITLE
Data Container Refactoring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,6 +46,7 @@ csharp_preferred_modifier_order = public, private, protected, internal, new, sta
 csharp_style_var_elsewhere = true:suggestion
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_using_directive_placement = outside_namespace:warning
 dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:suggestion
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:suggestion
 dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:suggestion

--- a/WoWsShipBuilder.Common/Features/AccelerationCharts/AccelerationCharts.razor
+++ b/WoWsShipBuilder.Common/Features/AccelerationCharts/AccelerationCharts.razor
@@ -14,6 +14,7 @@
 @using WoWsShipBuilder.Infrastructure.Localization.Resources
 @using WoWsShipBuilder.Infrastructure.Metrics
 @using WoWsShipBuilder.Infrastructure.Utility
+@using System.Collections.Immutable
 
 @inject ILocalizer Localizer
 @inject IDialogService DialogService
@@ -125,7 +126,7 @@
 
             NavManager.TryGetQueryString("shipIndexes", out string shipIndexesFromUrl);
 
-            IEnumerable<ShipBuildContainer>? buildContainers = SessionStateCache.GetAndResetBuildTransferContainers() ?? (!string.IsNullOrWhiteSpace(shipIndexesFromUrl) ? shipIndexesFromUrl.Split(',').Select(x => ShipBuildContainer.CreateNew(AppData.ShipDictionary[x], null, null)) : null);
+            IEnumerable<ShipBuildContainer>? buildContainers = SessionStateCache.GetAndResetBuildTransferContainers() ?? (!string.IsNullOrWhiteSpace(shipIndexesFromUrl) ? shipIndexesFromUrl.Split(',').Select(x => ShipBuildContainer.CreateNew(AppData.ShipDictionary[x], null, ImmutableArray<int>.Empty)) : null);
 
             if (buildContainers is not null)
             {
@@ -175,7 +176,7 @@
 
             List<IEnumerable<ChartsHelper.Point>> shipData = new()
             {
-                GetAccelerationData(shipWrapper.Ship, hull, engine, shipWrapper.Modifiers ?? new(), throttleList),
+                GetAccelerationData(shipWrapper.Ship, hull, engine, shipWrapper.Modifiers, throttleList),
             };
             var newChartData = new NewChartDataInput(shipWrapper.Id.ToString(), label, shipData, chartShipCounter);
             newData.Add(newChartData);
@@ -211,7 +212,7 @@
                 hull = shipWrapper.Ship.Hulls.First().Value;
             }
 
-            var updateChartData = new UpdateChartDataLabelInput(shipWrapper.Id.ToString(), shipWrapper.Id.ToString(), label, GetAccelerationData(shipWrapper.Ship, hull, engine, shipWrapper.Modifiers ?? new(), throttleList));
+            var updateChartData = new UpdateChartDataLabelInput(shipWrapper.Id.ToString(), shipWrapper.Id.ToString(), label, GetAccelerationData(shipWrapper.Ship, hull, engine, shipWrapper.Modifiers, throttleList));
             updatedData.Add(updateChartData);
         }
 
@@ -233,7 +234,7 @@
         await ChartJsInterop.CreateChartAsync(AccelerationId, Localizer.GetAppLocalization(nameof(Translation.AccelerationChart_Acceleration)).Localization, Localizer.GetAppLocalization(nameof(Translation.AccelerationChart_Time)).Localization, Localizer.GetAppLocalization(nameof(Translation.ShipStats_Speed)).Localization, s, knots);
     }
 
-    private static IEnumerable<ChartsHelper.Point> GetAccelerationData(Ship ship, Hull hull, Engine engine, List<Modifier> modifiers, List<int> throttles)
+    private static IEnumerable<ChartsHelper.Point> GetAccelerationData(Ship ship, Hull hull, Engine engine, ImmutableList<Modifier> modifiers, List<int> throttles)
     {
         decimal maxSpeedModifier = modifiers.ApplyModifiers("ManeuverabilityDataContainer.Speed", 1m);
 

--- a/WoWsShipBuilder.Common/Features/AccelerationCharts/CustomAccelerationDataDialog.razor
+++ b/WoWsShipBuilder.Common/Features/AccelerationCharts/CustomAccelerationDataDialog.razor
@@ -156,7 +156,7 @@
             ShipConsumable = ImmutableList<ShipConsumable>.Empty,
         };
 
-        var container = ShipBuildContainer.CreateNew(ship, null, null);
+        var container = ShipBuildContainer.CreateNew(ship, null, ImmutableArray<int>.Empty);
         MudDialog.Close(DialogResult.Ok(container));
     }
 

--- a/WoWsShipBuilder.Common/Features/BallisticCharts/Charts.razor
+++ b/WoWsShipBuilder.Common/Features/BallisticCharts/Charts.razor
@@ -12,6 +12,7 @@
 @using WoWsShipBuilder.Infrastructure.Localization.Resources
 @using WoWsShipBuilder.Infrastructure.Metrics
 @using WoWsShipBuilder.Infrastructure.Utility
+@using System.Collections.Immutable
 
 @inject NavigationManager NavManager
 @inject ILocalizer Localizer
@@ -338,7 +339,7 @@
             await SetupChartsAsync();
             if (shipIndexesFromUrl.Any())
             {
-                IEnumerable<ShipBuildContainer>? buildContainers = SessionStateCache.GetAndResetBuildTransferContainers() ?? (shipIndexesFromUrl.Any() ? shipIndexesFromUrl.Select(x =>  ShipBuildContainer.CreateNew(AppData.ShipDictionary[x], null, null) with { ShipDataContainer = DataContainerUtility.GetStockShipDataContainer(AppData.ShipDictionary[x]) }) : null);
+                IEnumerable<ShipBuildContainer>? buildContainers = SessionStateCache.GetAndResetBuildTransferContainers() ?? (shipIndexesFromUrl.Any() ? shipIndexesFromUrl.Select(x =>  ShipBuildContainer.CreateNew(AppData.ShipDictionary[x], null, ImmutableArray<int>.Empty) with { ShipDataContainer = DataContainerUtility.GetStockShipDataContainer(AppData.ShipDictionary[x]) }) : null);
                 if (buildContainers is not null)
                 {
                     List<ChartsDataWrapper> shipsToAdd = new();

--- a/WoWsShipBuilder.Common/Features/BallisticCharts/ShipAndShellSelectionDialog.razor
+++ b/WoWsShipBuilder.Common/Features/BallisticCharts/ShipAndShellSelectionDialog.razor
@@ -233,7 +233,7 @@
                 var shipConfiguration = Helpers.GetStockShipConfiguration(ship);
                 UpgradeModuleInShipConfiguration(shipConfiguration, commonHull);
                 UpgradeModuleInShipConfiguration(shipConfiguration, commonArtillery);
-                var dataContainer = ShipDataContainer.CreateFromShip(ship, shipConfiguration, wrapper.ShipBuildContainer.Modifiers ?? new());
+                var dataContainer = ShipDataContainer.CreateFromShip(ship, shipConfiguration.ToImmutableList(), wrapper.ShipBuildContainer.Modifiers ?? new());
                 Build build = new(string.Empty, ship.Index, ship.ShipNation, shipConfiguration.Select(x => x.Name.NameToIndex()).ToList(), ImmutableArray<string>.Empty, GetStockConsumableNames(ship), "PCW001", ImmutableArray<int>.Empty, ImmutableArray<string>.Empty);
                 var container = wrapper.ShipBuildContainer with { ShipDataContainer = dataContainer, Build = build };
                 var newWrapper = wrapper with { ShipBuildContainer = container };
@@ -245,7 +245,7 @@
                 var shipConfiguration = Helpers.GetShipConfigurationFromBuild(build.Modules, ship.ShipUpgradeInfo.ShipUpgrades);
                 UpgradeModuleInShipConfiguration(shipConfiguration, commonHull);
                 UpgradeModuleInShipConfiguration(shipConfiguration, commonArtillery);
-                var dataContainer = ShipDataContainer.CreateFromShip(ship, shipConfiguration, wrapper.ShipBuildContainer.Modifiers ?? new());
+                var dataContainer = ShipDataContainer.CreateFromShip(ship, shipConfiguration.ToImmutableList(), wrapper.ShipBuildContainer.Modifiers ?? new());
                 Build newBuild = new(build.BuildName, ship.Index, ship.ShipNation, shipConfiguration.Select(x => x.Name.NameToIndex()).ToList(), build.Upgrades.ToList(), build.Consumables.ToList(), build.Captain, build.Skills.ToList(), build.Signals.ToList());
                 var container = wrapper.ShipBuildContainer with { ShipDataContainer = dataContainer, Build = newBuild };
                 var newWrapper = wrapper with { ShipBuildContainer = container };

--- a/WoWsShipBuilder.Common/Features/BallisticCharts/ShipAndShellSelectionDialog.razor
+++ b/WoWsShipBuilder.Common/Features/BallisticCharts/ShipAndShellSelectionDialog.razor
@@ -233,7 +233,7 @@
                 var shipConfiguration = Helpers.GetStockShipConfiguration(ship);
                 UpgradeModuleInShipConfiguration(shipConfiguration, commonHull);
                 UpgradeModuleInShipConfiguration(shipConfiguration, commonArtillery);
-                var dataContainer = ShipDataContainer.CreateFromShip(ship, shipConfiguration.ToImmutableList(), wrapper.ShipBuildContainer.Modifiers ?? new());
+                var dataContainer = ShipDataContainer.CreateFromShip(ship, shipConfiguration.ToImmutableList(), wrapper.ShipBuildContainer.Modifiers);
                 Build build = new(string.Empty, ship.Index, ship.ShipNation, shipConfiguration.Select(x => x.Name.NameToIndex()).ToList(), ImmutableArray<string>.Empty, GetStockConsumableNames(ship), "PCW001", ImmutableArray<int>.Empty, ImmutableArray<string>.Empty);
                 var container = wrapper.ShipBuildContainer with { ShipDataContainer = dataContainer, Build = build };
                 var newWrapper = wrapper with { ShipBuildContainer = container };
@@ -245,7 +245,7 @@
                 var shipConfiguration = Helpers.GetShipConfigurationFromBuild(build.Modules, ship.ShipUpgradeInfo.ShipUpgrades);
                 UpgradeModuleInShipConfiguration(shipConfiguration, commonHull);
                 UpgradeModuleInShipConfiguration(shipConfiguration, commonArtillery);
-                var dataContainer = ShipDataContainer.CreateFromShip(ship, shipConfiguration.ToImmutableList(), wrapper.ShipBuildContainer.Modifiers ?? new());
+                var dataContainer = ShipDataContainer.CreateFromShip(ship, shipConfiguration.ToImmutableList(), wrapper.ShipBuildContainer.Modifiers);
                 Build newBuild = new(build.BuildName, ship.Index, ship.ShipNation, shipConfiguration.Select(x => x.Name.NameToIndex()).ToList(), build.Upgrades.ToList(), build.Consumables.ToList(), build.Captain, build.Skills.ToList(), build.Signals.ToList());
                 var container = wrapper.ShipBuildContainer with { ShipDataContainer = dataContainer, Build = newBuild };
                 var newWrapper = wrapper with { ShipBuildContainer = container };

--- a/WoWsShipBuilder.Common/Features/Builds/Components/BuildConfigurationDialog.razor
+++ b/WoWsShipBuilder.Common/Features/Builds/Components/BuildConfigurationDialog.razor
@@ -1,5 +1,6 @@
 ﻿@using Prometheus
 @using System.Collections.Concurrent
+@using System.Collections.Immutable
 @using Microsoft.Extensions.Hosting
 @using Microsoft.Extensions.Options
 @using WoWsShipBuilder.DataStructures.Ship
@@ -274,7 +275,7 @@
         using (MetricsService.ShipViewModelInitDuration.NewTimer())
         {
             var vm = ShipBuildViewModel.Create(shipBuildContainer);
-            foreach (int slot in shipBuildContainer.ActivatedConsumableSlots ?? Array.Empty<int>())
+            foreach (int slot in shipBuildContainer.ActivatedConsumableSlots)
             {
                 vm.ConsumableViewModel.ConsumableSlots[slot].ConsumableActivated = true;
             }
@@ -295,7 +296,7 @@
 
     private async Task ResetBuild()
     {
-        var vm = LoadShipViewModel(SelectedContainer with { Build = null, ActivatedConsumableSlots = null, SpecialAbilityActive = false });
+        var vm = LoadShipViewModel(SelectedContainer with { Build = null, ActivatedConsumableSlots = ImmutableArray<int>.Empty, SpecialAbilityActive = false });
         ViewModel = vm;
         vmCache[SelectedContainer.Id] = vm;
         await Task.Delay(1); // needed for the captain skill selector to rerender properly
@@ -317,7 +318,7 @@
                 throw new FormatException();
             }
 
-            ViewModel = LoadShipViewModel(ShipBuildContainer.CreateNew(ship, build, null));
+            ViewModel = LoadShipViewModel(ShipBuildContainer.CreateNew(ship, build, ImmutableArray<int>.Empty));
             inputBuildString = string.Empty;
             buildString = string.Empty;
             vmCache[SelectedContainer.Id] = ViewModel;

--- a/WoWsShipBuilder.Common/Features/Builds/ShipBuildViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/Builds/ShipBuildViewModel.cs
@@ -81,8 +81,8 @@ public partial class ShipBuildViewModel : ReactiveObject
     public ShipBuildContainer CreateShipBuildContainer(ShipBuildContainer baseContainer)
     {
         var build = this.DumpToBuild();
-        List<int>? activatedConsumables = this.ConsumableViewModel.ActivatedSlots.Any() ? this.ConsumableViewModel.ActivatedSlots.ToList() : null;
-        List<Modifier> modifiers = this.GenerateModifierList();
+        var activatedConsumables = this.ConsumableViewModel.ActivatedSlots.Any() ? this.ConsumableViewModel.ActivatedSlots.ToImmutableArray() : ImmutableArray<int>.Empty;
+        ImmutableList<Modifier> modifiers = this.GenerateModifierList();
         return baseContainer with
         {
             Build = build,
@@ -93,12 +93,12 @@ public partial class ShipBuildViewModel : ReactiveObject
         };
     }
 
-    private ShipDataContainer CreateDataContainer(List<Modifier> modifiers)
+    private ShipDataContainer CreateDataContainer(ImmutableList<Modifier> modifiers)
     {
         return ShipDataContainer.CreateFromShip(this.CurrentShip, this.ShipModuleViewModel.SelectedModules.ToImmutableList(), modifiers);
     }
 
-    private List<Modifier> GenerateModifierList()
+    private ImmutableList<Modifier> GenerateModifierList()
     {
         var modifiers = new List<Modifier>();
 
@@ -106,6 +106,6 @@ public partial class ShipBuildViewModel : ReactiveObject
         modifiers.AddRange(this.SignalSelectorViewModel.GetModifierList());
         modifiers.AddRange(this.CaptainSkillSelectorViewModel.GetModifiersList());
         modifiers.AddRange(this.ConsumableViewModel.GetModifiersList());
-        return modifiers;
+        return modifiers.ToImmutableList();
     }
 }

--- a/WoWsShipBuilder.Common/Features/Builds/ShipBuildViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/Builds/ShipBuildViewModel.cs
@@ -1,4 +1,5 @@
-﻿using ReactiveUI;
+﻿using System.Collections.Immutable;
+using ReactiveUI;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
 using WoWsShipBuilder.Features.DataContainers;
@@ -94,7 +95,7 @@ public partial class ShipBuildViewModel : ReactiveObject
 
     private ShipDataContainer CreateDataContainer(List<Modifier> modifiers)
     {
-        return ShipDataContainer.CreateFromShip(this.CurrentShip, this.ShipModuleViewModel.SelectedModules.ToList(), modifiers);
+        return ShipDataContainer.CreateFromShip(this.CurrentShip, this.ShipModuleViewModel.SelectedModules.ToImmutableList(), modifiers);
     }
 
     private List<Modifier> GenerateModifierList()

--- a/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/AirstrikeDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/AirstrikeDataContainer.cs
@@ -50,7 +50,7 @@ public partial class AirstrikeDataContainer : DataContainerBase
 
     public ProjectileDataContainer? Weapon { get; set; }
 
-    public static AirstrikeDataContainer? FromShip(Ship ship, List<Modifier> modifiers, bool isAsw)
+    public static AirstrikeDataContainer? FromShip(Ship ship, ImmutableList<Modifier> modifiers, bool isAsw)
     {
         string header = isAsw ? "ShipStats_AswAirstrike" : "ShipStats_Airstrike";
         ImmutableDictionary<string, AirStrike> airstrikes = ship.AirStrikes;

--- a/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/AirstrikeDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/AirstrikeDataContainer.cs
@@ -9,7 +9,7 @@ using WoWsShipBuilder.Infrastructure.ApplicationData;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record AirstrikeDataContainer : DataContainerBase
+public partial class AirstrikeDataContainer : DataContainerBase
 {
     public string Header { get; set; } = default!;
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/CvAircraftDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/CvAircraftDataContainer.cs
@@ -11,7 +11,7 @@ using WoWsShipBuilder.Infrastructure.GameData;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record CvAircraftDataContainer : DataContainerBase
+public partial class CvAircraftDataContainer : DataContainerBase
 {
     public string Name { get; set; } = default!;
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/CvAircraftDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/CvAircraftDataContainer.cs
@@ -109,7 +109,7 @@ public partial class CvAircraftDataContainer : DataContainerBase
 
     public decimal BoostReloadTime { get; set; }
 
-    public static List<CvAircraftDataContainer>? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static List<CvAircraftDataContainer>? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         if (ship.CvPlanes.IsEmpty)
         {
@@ -159,7 +159,7 @@ public partial class CvAircraftDataContainer : DataContainerBase
         return list;
     }
 
-    private static CvAircraftDataContainer ProcessCvPlane(Aircraft plane, int shipTier, List<Modifier> modifiers)
+    private static CvAircraftDataContainer ProcessCvPlane(Aircraft plane, int shipTier, ImmutableList<Modifier> modifiers)
     {
         int maxOnDeck = modifiers.ApplyModifiers("CvAircraftDataContainer.MaxOnDeck", plane.MaxPlaneInHangar);
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/CvAircraftDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/CvAircraftDataContainer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Globalization;
 using WoWsShipBuilder.DataElements;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
@@ -108,7 +109,7 @@ public partial class CvAircraftDataContainer : DataContainerBase
 
     public decimal BoostReloadTime { get; set; }
 
-    public static List<CvAircraftDataContainer>? FromShip(Ship ship, List<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static List<CvAircraftDataContainer>? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         if (ship.CvPlanes.IsEmpty)
         {

--- a/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/CvAircraftDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Aircraft/CvAircraftDataContainer.cs
@@ -100,7 +100,7 @@ public partial class CvAircraftDataContainer : DataContainerBase
 
     public ProjectileDataContainer? Weapon { get; set; }
 
-    public List<ConsumableDataContainer> PlaneConsumables { get; set; } = default!;
+    public ImmutableList<ConsumableDataContainer> PlaneConsumables { get; set; } = ImmutableList<ConsumableDataContainer>.Empty;
 
     // TODO
     public decimal ArmamentReloadTime { get; set; }
@@ -308,7 +308,7 @@ public partial class CvAircraftDataContainer : DataContainerBase
             JatoSpeedMultiplier = Math.Round(jatoSpeedMultiplier, 0),
             WeaponType = weaponType.ProjectileTypeToString(),
             Weapon = weapon,
-            PlaneConsumables = consumables,
+            PlaneConsumables = consumables.ToImmutableList(),
             AimingTime = Math.Round(aimingTime, 1),
             PreparationTime = plane.PreparationTime,
             PostAttackInvulnerabilityDuration = plane.PostAttackInvulnerabilityDuration,

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/DepthChargesLauncherDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/DepthChargesLauncherDataContainer.cs
@@ -21,7 +21,7 @@ public partial class DepthChargesLauncherDataContainer : DataContainerBase
 
     public DepthChargeDataContainer? DepthCharge { get; set; }
 
-    public static DepthChargesLauncherDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static DepthChargesLauncherDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         var shipHull = ship.Hulls[shipConfiguration.First(upgrade => upgrade.UcType == ComponentType.Hull).Components[ComponentType.Hull][0]];
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/DepthChargesLauncherDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/DepthChargesLauncherDataContainer.cs
@@ -1,9 +1,9 @@
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataElements;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
-using WoWsShipBuilder.Infrastructure.Utility;
 
 namespace WoWsShipBuilder.Features.DataContainers;
 
@@ -21,7 +21,7 @@ public partial class DepthChargesLauncherDataContainer : DataContainerBase
 
     public DepthChargeDataContainer? DepthCharge { get; set; }
 
-    public static DepthChargesLauncherDataContainer? FromShip(Ship ship, List<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static DepthChargesLauncherDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         var shipHull = ship.Hulls[shipConfiguration.First(upgrade => upgrade.UcType == ComponentType.Hull).Components[ComponentType.Hull][0]];
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/DepthChargesLauncherDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/DepthChargesLauncherDataContainer.cs
@@ -8,7 +8,7 @@ using WoWsShipBuilder.Infrastructure.Utility;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record DepthChargesLauncherDataContainer : DataContainerBase
+public partial class DepthChargesLauncherDataContainer : DataContainerBase
 {
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
     public decimal Reload { get; set; }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
@@ -11,7 +11,7 @@ using WoWsShipBuilder.Infrastructure.GameData;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record MainBatteryDataContainer : DataContainerBase
+public partial class MainBatteryDataContainer : DataContainerBase
 {
     [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = "TurretNames", ArgumentsTextKind = TextKind.LocalizationKey)]
     public string Name { get; set; } = default!;

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections.Immutable;
+using System.Globalization;
 using System.Text;
 using WoWsShipBuilder.DataElements;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
@@ -103,7 +104,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
 
     public string BarrelsLayout { get; set; } = default!;
 
-    public static MainBatteryDataContainer? FromShip(Ship ship, List<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static MainBatteryDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         var artilleryConfiguration = shipConfiguration.Find(c => c.UcType == ComponentType.Artillery);
         if (artilleryConfiguration == null)

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
@@ -17,7 +17,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
     [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = "TurretNames", ArgumentsTextKind = TextKind.LocalizationKey)]
     public string Name { get; set; } = default!;
 
-    public List<string> TurretNames { get; set; } = new();
+    public ImmutableList<string> TurretNames { get; set; } = ImmutableList<string>.Empty;
 
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "KM")]
     public decimal Range { get; set; }
@@ -84,7 +84,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
 
     public decimal TaperDist { get; set; }
 
-    public List<ShellDataContainer> ShellData { get; set; } = default!;
+    public ImmutableList<ShellDataContainer> ShellData { get; set; } = ImmutableList<ShellDataContainer>.Empty;
 
     public Dispersion DispersionData { get; set; } = default!;
 
@@ -183,7 +183,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
         var mainBatteryDataContainer = new MainBatteryDataContainer
         {
             Name = arrangementString.ToString(),
-            TurretNames = turretNames,
+            TurretNames = turretNames.ToImmutableList(),
             Range = Math.Round(range, 2),
             Reload = Math.Round(reload, 2),
             AmmoSwitchTime = Math.Round(ammoSwitchTime, 2),
@@ -202,7 +202,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
             DispersionData = dispersion,
             DispersionModifier = dispersionModifier,
             OriginalMainBatteryData = mainBattery,
-            ShellData = shellData,
+            ShellData = shellData.ToImmutableList(),
             DisplayHeDpm = shellData.Select(x => x.Type).Contains($"ArmamentType_{ShellType.HE.ShellTypeToString()}"),
             DisplayApDpm = shellData.Select(x => x.Type).Contains($"ArmamentType_{ShellType.AP.ShellTypeToString()}"),
             DisplaySapDpm = shellData.Select(x => x.Type).Contains($"ArmamentType_{ShellType.SAP.ShellTypeToString()}"),

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
@@ -104,7 +104,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
 
     public string BarrelsLayout { get; set; } = default!;
 
-    public static MainBatteryDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static MainBatteryDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         var artilleryConfiguration = shipConfiguration.Find(c => c.UcType == ComponentType.Artillery);
         if (artilleryConfiguration == null)

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/PingerGunDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/PingerGunDataContainer.cs
@@ -36,7 +36,7 @@ public partial class PingerGunDataContainer : DataContainerBase
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "MPS")]
     public decimal PingSpeed { get; set; }
 
-    public static PingerGunDataContainer? FromShip(Ship ship, IEnumerable<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static PingerGunDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         if (ship.PingerGunList.IsEmpty)
         {

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/PingerGunDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/PingerGunDataContainer.cs
@@ -10,7 +10,7 @@ using WoWsShipBuilder.Infrastructure.Utility;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record PingerGunDataContainer : DataContainerBase
+public partial class PingerGunDataContainer : DataContainerBase
 {
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
     public decimal Reload { get; set; }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/PingerGunDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/PingerGunDataContainer.cs
@@ -36,7 +36,7 @@ public partial class PingerGunDataContainer : DataContainerBase
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "MPS")]
     public decimal PingSpeed { get; set; }
 
-    public static PingerGunDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static PingerGunDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         if (ship.PingerGunList.IsEmpty)
         {
@@ -44,7 +44,7 @@ public partial class PingerGunDataContainer : DataContainerBase
         }
 
         PingerGun pingerGun;
-        var pingerUpgrade = shipConfiguration.FirstOrDefault(c => c.UcType == ComponentType.Sonar);
+        var pingerUpgrade = shipConfiguration.Find(c => c.UcType == ComponentType.Sonar);
         if (pingerUpgrade is null && ship.PingerGunList.Count is 1)
         {
             Logging.Logger.LogWarning("No sonar upgrade information found for ship {ShipName} even though there is one sonar module available", ship.Name);

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryDataContainer.cs
@@ -16,7 +16,7 @@ public partial class SecondaryBatteryDataContainer : DataContainerBase
 {
     public string Name { get; set; } = default!;
 
-    public List<string> TurretName { get; set; } = new();
+    public ImmutableList<string> TurretName { get; set; } = ImmutableList<string>.Empty;
 
     public FormattedTextDataElement TurretSetup { get; set; } = default!;
 
@@ -106,7 +106,7 @@ public partial class SecondaryBatteryDataContainer : DataContainerBase
             var secondaryBatteryDataContainer = new SecondaryBatteryDataContainer
             {
                 Name = arrangementString,
-                TurretName = turretName,
+                TurretName = turretName.ToImmutableList(),
                 TurretSetup = new(arrangementString, turretName, ArgumentsTextKind: DataElementTextKind.LocalizationKey),
                 BarrelsLayout = $"{secondaryGroup.Count} x {secondaryGun.NumBarrels}",
                 BarrelsCount = secondaryGroup.Count * secondaryGun.NumBarrels,

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryDataContainer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 using WoWsShipBuilder.DataElements;
@@ -65,7 +66,7 @@ public partial class SecondaryBatteryDataContainer : DataContainerBase
 
     public double DispersionModifier { get; set; }
 
-    public static List<SecondaryBatteryDataContainer>? FromShip(Ship ship, IEnumerable<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static List<SecondaryBatteryDataContainer>? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         var secondary = ship.Hulls[shipConfiguration.First(c => c.UcType == ComponentType.Hull).Components[ComponentType.Hull][0]].SecondaryModule;
         if (secondary == null)

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryDataContainer.cs
@@ -11,7 +11,7 @@ using WoWsShipBuilder.Infrastructure.Utility;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record SecondaryBatteryDataContainer : DataContainerBase
+public partial class SecondaryBatteryDataContainer : DataContainerBase
 {
     public string Name { get; set; } = default!;
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryUiDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryUiDataContainer.cs
@@ -31,7 +31,7 @@ public partial class SecondaryBatteryUiDataContainer : DataContainerBase
 
     public required ImmutableList<SecondaryBatteryDataContainer> Secondaries { get; init; }
 
-    public static SecondaryBatteryUiDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static SecondaryBatteryUiDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         var secondaries = SecondaryBatteryDataContainer.FromShip(ship, shipConfiguration, modifiers);
         var secondaryBatteryUiDataContainer = new SecondaryBatteryUiDataContainer

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryUiDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryUiDataContainer.cs
@@ -31,7 +31,7 @@ public partial class SecondaryBatteryUiDataContainer : DataContainerBase
 
     public required ImmutableList<SecondaryBatteryDataContainer> Secondaries { get; init; }
 
-    public static SecondaryBatteryUiDataContainer FromShip(Ship ship, IEnumerable<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static SecondaryBatteryUiDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         var secondaries = SecondaryBatteryDataContainer.FromShip(ship, shipConfiguration, modifiers);
         var secondaryBatteryUiDataContainer = new SecondaryBatteryUiDataContainer

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryUiDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryUiDataContainer.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections.Immutable;
+using System.Globalization;
 using WoWsShipBuilder.DataElements;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures.Modifiers;
@@ -7,26 +8,41 @@ using WoWsShipBuilder.DataStructures.Ship;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record SecondaryBatteryUiDataContainer(List<SecondaryBatteryDataContainer>? Secondaries) : DataContainerBase
+public partial class SecondaryBatteryUiDataContainer : DataContainerBase
 {
+    private SecondaryBatteryUiDataContainer()
+    {
+    }
+
     [DataElementType(DataElementTypes.KeyValue, ValueTextKind = TextKind.AppLocalizationKey)]
-    public string ShellType { get; } = Secondaries?[0].Shell?.Type ?? string.Empty;
+    public string ShellType { get; init; } = string.Empty;
 
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "KM")]
-    public decimal Range { get; } = Secondaries?[0].Range ?? 0;
+    public decimal Range { get; init; }
 
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Overall", UnitKey = "ShotsPerMinute", LocalizationKeyOverride = "RoF")]
-    public decimal TotalRoF { get; } = Secondaries?.Sum(x => x.RoF) ?? 0;
+    public decimal TotalRoF { get; init; }
 
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue, GroupKey = "Overall", LocalizationKeyOverride = "Dpm")]
-    public string TotalDpm { get; } = Secondaries?.Sum(x => x.Dpm).ToString("n0", SetNumberGroupSeparator()) ?? "";
+    public string TotalDpm { get; init; } = string.Empty;
 
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Overall", UnitKey = "FPM", LocalizationKeyOverride = "PotentialFpm")]
-    public decimal TotalFpm { get; } = Secondaries?.Sum(x => x.PotentialFpm) ?? 0;
+    public decimal TotalFpm { get; init; }
+
+    public required ImmutableList<SecondaryBatteryDataContainer> Secondaries { get; init; }
 
     public static SecondaryBatteryUiDataContainer FromShip(Ship ship, IEnumerable<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
-        var secondaryBatteryUiDataContainer = new SecondaryBatteryUiDataContainer(SecondaryBatteryDataContainer.FromShip(ship, shipConfiguration, modifiers));
+        var secondaries = SecondaryBatteryDataContainer.FromShip(ship, shipConfiguration, modifiers);
+        var secondaryBatteryUiDataContainer = new SecondaryBatteryUiDataContainer
+        {
+            Secondaries = secondaries?.ToImmutableList() ?? ImmutableList<SecondaryBatteryDataContainer>.Empty,
+            ShellType = secondaries?[0].Shell?.Type ?? string.Empty,
+            Range = secondaries?[0].Range ?? 0,
+            TotalRoF = secondaries?.Sum(x => x.RoF) ?? 0,
+            TotalDpm = secondaries?.Sum(x => x.Dpm).ToString("n0", SetNumberGroupSeparator()) ?? "",
+            TotalFpm = secondaries?.Sum(x => x.PotentialFpm) ?? 0,
+        };
         secondaryBatteryUiDataContainer.UpdateDataElements();
         return secondaryBatteryUiDataContainer;
     }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/TorpedoArmamentDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/TorpedoArmamentDataContainer.cs
@@ -63,7 +63,7 @@ public partial class TorpedoArmamentDataContainer : DataContainerBase
 
     public IEnumerable<TorpedoLauncher> TorpedoLaunchers { get; private set; } = default!;
 
-    public static TorpedoArmamentDataContainer? FromShip(Ship ship, List<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static TorpedoArmamentDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         var torpConfiguration = shipConfiguration.Find(c => c.UcType == ComponentType.Torpedoes);
         if (torpConfiguration == null)

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/TorpedoArmamentDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/TorpedoArmamentDataContainer.cs
@@ -63,7 +63,7 @@ public partial class TorpedoArmamentDataContainer : DataContainerBase
 
     public IEnumerable<TorpedoLauncher> TorpedoLaunchers { get; private set; } = default!;
 
-    public static TorpedoArmamentDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static TorpedoArmamentDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         var torpConfiguration = shipConfiguration.Find(c => c.UcType == ComponentType.Torpedoes);
         if (torpConfiguration == null)

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/TorpedoArmamentDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/TorpedoArmamentDataContainer.cs
@@ -10,7 +10,7 @@ using WoWsShipBuilder.DataStructures.Ship;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record TorpedoArmamentDataContainer : DataContainerBase
+public partial class TorpedoArmamentDataContainer : DataContainerBase
 {
     [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = "LauncherNames", ArgumentsTextKind = TextKind.LocalizationKey)]
     public string Name { get; set; } = default!;

--- a/WoWsShipBuilder.Common/Features/DataContainers/Armament/TorpedoArmamentDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Armament/TorpedoArmamentDataContainer.cs
@@ -15,7 +15,7 @@ public partial class TorpedoArmamentDataContainer : DataContainerBase
     [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = "LauncherNames", ArgumentsTextKind = TextKind.LocalizationKey)]
     public string Name { get; set; } = default!;
 
-    public List<string> LauncherNames { get; set; } = new();
+    public ImmutableList<string> LauncherNames { get; set; } = ImmutableList<string>.Empty;
 
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue, GroupKey = "Loaders")]
     public string BowLoaders { get; set; } = default!;
@@ -59,7 +59,7 @@ public partial class TorpedoArmamentDataContainer : DataContainerBase
 
     public string TorpLayout { get; set; } = default!;
 
-    public List<TorpedoDataContainer> Torpedoes { get; set; } = new();
+    public ImmutableList<TorpedoDataContainer> Torpedoes { get; set; } = ImmutableList<TorpedoDataContainer>.Empty;
 
     public IEnumerable<TorpedoLauncher> TorpedoLaunchers { get; private set; } = default!;
 
@@ -131,12 +131,12 @@ public partial class TorpedoArmamentDataContainer : DataContainerBase
         var torpedoArmamentDataContainer = new TorpedoArmamentDataContainer
         {
             Name = arrangementString.ToString(),
-            LauncherNames = launcherNames,
+            LauncherNames = launcherNames.ToImmutableList(),
             TurnTime = Math.Round(180 / traverseSpeed, 1),
             TraverseSpeed = Math.Round(traverseSpeed, 2),
             Reload = Math.Round(reloadSpeed, 2),
             TorpedoArea = torpedoArea,
-            Torpedoes = torpedoes,
+            Torpedoes = torpedoes.ToImmutableList(),
             TimeToSwitch = Math.Round(reloadSpeed * launcher.AmmoSwitchCoeff, 1),
             TorpedoLaunchers = torpedoModule.TorpedoLaunchers,
             TorpLayout = string.Join(" + ", torpLayout),

--- a/WoWsShipBuilder.Common/Features/DataContainers/DataContainerUtility.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/DataContainerUtility.cs
@@ -1,4 +1,5 @@
-﻿using WoWsShipBuilder.DataStructures.Modifiers;
+﻿using System.Collections.Immutable;
+using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
 using WoWsShipBuilder.Infrastructure.Utility;
 
@@ -8,12 +9,12 @@ public static class DataContainerUtility
 {
     public static ShipDataContainer GetShipDataContainerFromBuild(Ship ship, IEnumerable<string> selectedModules, IEnumerable<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
-        return ShipDataContainer.CreateFromShip(ship, Helpers.GetShipConfigurationFromBuild(selectedModules, shipConfiguration), modifiers);
+        return ShipDataContainer.CreateFromShip(ship, Helpers.GetShipConfigurationFromBuild(selectedModules, shipConfiguration).ToImmutableList(), modifiers);
     }
 
     public static ShipDataContainer GetStockShipDataContainer(Ship ship)
     {
-        return ShipDataContainer.CreateFromShip(ship, Helpers.GetStockShipConfiguration(ship), new());
+        return ShipDataContainer.CreateFromShip(ship, Helpers.GetStockShipConfiguration(ship).ToImmutableList(), new());
     }
 
     public static decimal ApplyModifiers(this List<Modifier> modifierList, string propertySelector, decimal initialValue)

--- a/WoWsShipBuilder.Common/Features/DataContainers/DataContainerUtility.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/DataContainerUtility.cs
@@ -7,17 +7,22 @@ namespace WoWsShipBuilder.Features.DataContainers;
 
 public static class DataContainerUtility
 {
-    public static ShipDataContainer GetShipDataContainerFromBuild(Ship ship, IEnumerable<string> selectedModules, IEnumerable<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static ShipDataContainer GetShipDataContainerFromBuild(Ship ship, IEnumerable<string> selectedModules, IEnumerable<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         return ShipDataContainer.CreateFromShip(ship, Helpers.GetShipConfigurationFromBuild(selectedModules, shipConfiguration).ToImmutableList(), modifiers);
     }
 
     public static ShipDataContainer GetStockShipDataContainer(Ship ship)
     {
-        return ShipDataContainer.CreateFromShip(ship, Helpers.GetStockShipConfiguration(ship).ToImmutableList(), new());
+        return ShipDataContainer.CreateFromShip(ship, Helpers.GetStockShipConfiguration(ship).ToImmutableList(), ImmutableList<Modifier>.Empty);
     }
 
     public static decimal ApplyModifiers(this List<Modifier> modifierList, string propertySelector, decimal initialValue)
+    {
+        return modifierList.FindAll(x => x.AffectedProperties.Contains(propertySelector)).Aggregate(initialValue, (total, current) => current.ApplyModifier(total));
+    }
+
+    public static decimal ApplyModifiers(this ImmutableList<Modifier> modifierList, string propertySelector, decimal initialValue)
     {
         return modifierList.FindAll(x => x.AffectedProperties.Contains(propertySelector)).Aggregate(initialValue, (total, current) => current.ApplyModifier(total));
     }
@@ -27,7 +32,12 @@ public static class DataContainerUtility
         return modifierList.FindAll(x => x.AffectedProperties.Contains(propertySelector)).Aggregate(initialValue, (total, current) => current.ApplyModifier(total));
     }
 
-    public static void UpdateConsumableModifierValue(this List<Modifier> consumableModifierList, List<Modifier> modifierList, string propertySelector, string modifierName)
+    public static int ApplyModifiers(this ImmutableList<Modifier> modifierList, string propertySelector, int initialValue)
+    {
+        return modifierList.FindAll(x => x.AffectedProperties.Contains(propertySelector)).Aggregate(initialValue, (total, current) => current.ApplyModifier(total));
+    }
+
+    public static void UpdateConsumableModifierValue(this List<Modifier> consumableModifierList, ImmutableList<Modifier> modifierList, string propertySelector, string modifierName)
     {
         var modifier = consumableModifierList.Find(x => x.Name.Equals(modifierName));
         var newValue = (float)modifierList.ApplyModifiers(propertySelector, (decimal)(modifier?.Value ?? 0));

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/BombDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/BombDataContainer.cs
@@ -9,7 +9,7 @@ using WoWsShipBuilder.Infrastructure.Utility;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record BombDataContainer : ProjectileDataContainer
+public partial class BombDataContainer : ProjectileDataContainer
 {
     [DataElementType(DataElementTypes.KeyValue, ValueTextKind = TextKind.AppLocalizationKey)]
     public string BombType { get; set; } = default!;

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/BombDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/BombDataContainer.cs
@@ -1,10 +1,10 @@
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Projectile;
 using WoWsShipBuilder.Features.BallisticCharts;
 using WoWsShipBuilder.Infrastructure.ApplicationData;
 using WoWsShipBuilder.Infrastructure.GameData;
-using WoWsShipBuilder.Infrastructure.Utility;
 
 namespace WoWsShipBuilder.Features.DataContainers;
 
@@ -59,7 +59,7 @@ public partial class BombDataContainer : ProjectileDataContainer
 
     public bool ShowBlastPenetration { get; private set; }
 
-    public static BombDataContainer FromBombName(string name, List<Modifier> modifiers)
+    public static BombDataContainer FromBombName(string name, ImmutableList<Modifier> modifiers)
     {
         var bomb = AppData.FindProjectile<Bomb>(name);
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/DepthChargeDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/DepthChargeDataContainer.cs
@@ -1,8 +1,8 @@
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Projectile;
 using WoWsShipBuilder.Infrastructure.ApplicationData;
-using WoWsShipBuilder.Infrastructure.Utility;
 
 namespace WoWsShipBuilder.Features.DataContainers;
 
@@ -32,7 +32,7 @@ public partial class DepthChargeDataContainer : ProjectileDataContainer
 
     public Dictionary<float, List<float>> PointsOfDmg { get; set; } = default!;
 
-    public static DepthChargeDataContainer FromChargesName(string name, List<Modifier> modifiers)
+    public static DepthChargeDataContainer FromChargesName(string name, ImmutableList<Modifier> modifiers)
     {
         var depthCharge = AppData.FindProjectile<DepthCharge>(name);
         decimal damage = modifiers.ApplyModifiers("DepthChargeDataContainer.Damage", (decimal)depthCharge.Damage);

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/DepthChargeDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/DepthChargeDataContainer.cs
@@ -30,7 +30,7 @@ public partial class DepthChargeDataContainer : ProjectileDataContainer
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "PerCent")]
     public decimal FloodingChance { get; set; }
 
-    public Dictionary<float, List<float>> PointsOfDmg { get; set; } = default!;
+    public ImmutableDictionary<float, ImmutableList<float>> PointsOfDmg { get; set; } = ImmutableDictionary<float, ImmutableList<float>>.Empty;
 
     public static DepthChargeDataContainer FromChargesName(string name, ImmutableList<Modifier> modifiers)
     {
@@ -40,8 +40,8 @@ public partial class DepthChargeDataContainer : ProjectileDataContainer
         decimal maxSpeed = (decimal)(depthCharge.SinkingSpeed * (1 + depthCharge.SinkingSpeedRng)) * Constants.KnotsToMps;
         decimal minTimer = (decimal)(depthCharge.DetonationTimer - depthCharge.DetonationTimerRng);
         decimal maxTimer = (decimal)(depthCharge.DetonationTimer + depthCharge.DetonationTimerRng);
-        decimal minDetDepth = minSpeed * minTimer / 2;
-        decimal maxDetDepth = maxSpeed * maxTimer / 2;
+        decimal minDetDepth = (minSpeed * minTimer) / 2;
+        decimal maxDetDepth = (maxSpeed * maxTimer) / 2;
 
         var depthChargeDataContainer = new DepthChargeDataContainer
         {
@@ -52,7 +52,7 @@ public partial class DepthChargeDataContainer : ProjectileDataContainer
             SinkSpeed = $"{Math.Round(minSpeed, 1)} ~ {Math.Round(maxSpeed, 1)}",
             DetonationTimer = $"{Math.Round(minTimer, 1)} ~ {Math.Round(maxTimer, 1)}",
             DetonationDepth = $"{Math.Round(minDetDepth)} ~ {Math.Round(maxDetDepth)}",
-            PointsOfDmg = depthCharge.PointsOfDamage.ToDictionary(x => x.Key, x => x.Value.ToList()),
+            PointsOfDmg = depthCharge.PointsOfDamage.ToImmutableDictionary(x => x.Key, x => x.Value),
         };
 
         depthChargeDataContainer.UpdateDataElements();

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/DepthChargeDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/DepthChargeDataContainer.cs
@@ -7,7 +7,7 @@ using WoWsShipBuilder.Infrastructure.Utility;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record DepthChargeDataContainer : ProjectileDataContainer
+public partial class DepthChargeDataContainer : ProjectileDataContainer
 {
     [DataElementType(DataElementTypes.KeyValue)]
     public int Damage { get; set; }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/ProjectileDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/ProjectileDataContainer.cs
@@ -2,4 +2,6 @@ using WoWsShipBuilder.DataElements;
 
 namespace WoWsShipBuilder.Features.DataContainers;
 
-public abstract record ProjectileDataContainer : DataContainerBase;
+public abstract class ProjectileDataContainer : DataContainerBase
+{
+}

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/RocketDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/RocketDataContainer.cs
@@ -9,7 +9,7 @@ using WoWsShipBuilder.Infrastructure.Utility;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record RocketDataContainer : ProjectileDataContainer
+public partial class RocketDataContainer : ProjectileDataContainer
 {
     [DataElementType(DataElementTypes.KeyValue, ValueTextKind = TextKind.AppLocalizationKey)]
     public string RocketType { get; set; } = default!;

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/RocketDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/RocketDataContainer.cs
@@ -1,10 +1,10 @@
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Projectile;
 using WoWsShipBuilder.Features.BallisticCharts;
 using WoWsShipBuilder.Infrastructure.ApplicationData;
 using WoWsShipBuilder.Infrastructure.GameData;
-using WoWsShipBuilder.Infrastructure.Utility;
 
 namespace WoWsShipBuilder.Features.DataContainers;
 
@@ -56,7 +56,7 @@ public partial class RocketDataContainer : ProjectileDataContainer
 
     public bool ShowBlastPenetration { get; private set; }
 
-    public static RocketDataContainer FromRocketName(string name, List<Modifier> modifiers)
+    public static RocketDataContainer FromRocketName(string name, ImmutableList<Modifier> modifiers)
     {
         var rocket = AppData.FindProjectile<Rocket>(name);
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/ShellDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/ShellDataContainer.cs
@@ -11,7 +11,7 @@ using WoWsShipBuilder.Infrastructure.GameData;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record ShellDataContainer : DataContainerBase
+public partial class ShellDataContainer : DataContainerBase
 {
     public string Name { get; set; } = default!;
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/ShellDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/ShellDataContainer.cs
@@ -1,5 +1,6 @@
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataElements;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures;
@@ -81,14 +82,14 @@ public partial class ShellDataContainer : DataContainerBase
 
     public bool ShowBlastPenetration { get; private set; }
 
-    public static List<ShellDataContainer> FromShellName(IEnumerable<string> shellNames, List<Modifier> modifiers, int barrelCount, bool isMainGunShell)
+    public static List<ShellDataContainer> FromShellName(IEnumerable<string> shellNames, ImmutableList<Modifier> modifiers, int barrelCount, bool isMainGunShell)
     {
         var shells = shellNames.Select(shellName => ProcessShell(modifiers, barrelCount, isMainGunShell, shellName)).ToList();
         shells[^1].IsLastEntry = true;
         return shells;
     }
 
-    private static ShellDataContainer ProcessShell(List<Modifier> modifiers, int barrelCount, bool isMainGunShell, string shellName)
+    private static ShellDataContainer ProcessShell(ImmutableList<Modifier> modifiers, int barrelCount, bool isMainGunShell, string shellName)
     {
         var shell = AppData.FindProjectile<ArtilleryShell>(shellName);
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/TorpedoDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/TorpedoDataContainer.cs
@@ -1,10 +1,10 @@
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Projectile;
 using WoWsShipBuilder.Infrastructure.ApplicationData;
 using WoWsShipBuilder.Infrastructure.GameData;
-using WoWsShipBuilder.Infrastructure.Utility;
 
 namespace WoWsShipBuilder.Features.DataContainers;
 
@@ -118,7 +118,7 @@ public partial class TorpedoDataContainer : ProjectileDataContainer
 
     public bool IsFromPlane { get; set; }
 
-    public static List<TorpedoDataContainer> FromTorpedoName(IEnumerable<string> torpedoNames, List<Modifier> modifiers, bool fromPlane)
+    public static List<TorpedoDataContainer> FromTorpedoName(IEnumerable<string> torpedoNames, ImmutableList<Modifier> modifiers, bool fromPlane)
     {
         var list = new List<TorpedoDataContainer>();
         foreach (string name in torpedoNames)

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/TorpedoDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/TorpedoDataContainer.cs
@@ -112,7 +112,7 @@ public partial class TorpedoDataContainer : ProjectileDataContainer
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "AirCarrier", UnitKey = "M", LocalizationKeyOverride = "SecondPing")]
     public decimal CvCutOffSecondPing { get; set; }
 
-    public List<ShipClass>? CanHitClasses { get; set; }
+    public ImmutableList<ShipClass> CanHitClasses { get; set; } = ImmutableList<ShipClass>.Empty;
 
     public bool IsLast { get; set; }
 
@@ -189,7 +189,7 @@ public partial class TorpedoDataContainer : ProjectileDataContainer
 
             if (torp.IgnoreClasses != null && torp.IgnoreClasses.Any())
             {
-                torpedoDataContainer.CanHitClasses = allClasses.Except(torp.IgnoreClasses).ToList();
+                torpedoDataContainer.CanHitClasses = allClasses.Except(torp.IgnoreClasses).ToImmutableList();
             }
 
             torpedoDataContainer.UpdateDataElements();

--- a/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/TorpedoDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/TorpedoDataContainer.cs
@@ -9,7 +9,7 @@ using WoWsShipBuilder.Infrastructure.Utility;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record TorpedoDataContainer : ProjectileDataContainer
+public partial class TorpedoDataContainer : ProjectileDataContainer
 {
     [DataElementType(DataElementTypes.KeyValue, ValueTextKind = TextKind.AppLocalizationKey)]
     public string TorpedoType { get; set; } = default!;

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/AntiAirDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/AntiAirDataContainer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
@@ -18,7 +19,7 @@ public class AntiAirDataContainer
 
     public AuraDataDataContainer? ShortRangeAura { get; set; }
 
-    public static AntiAirDataContainer? FromShip(Ship ship, List<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static AntiAirDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         if (ship.ShipClass.Equals(ShipClass.Submarine))
         {

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/AntiAirDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/AntiAirDataContainer.cs
@@ -1,12 +1,11 @@
 using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
-using WoWsShipBuilder.Infrastructure.Utility;
 
 // ReSharper disable InconsistentNaming
 namespace WoWsShipBuilder.Features.DataContainers;
 
-public record AntiAirDataContainer
+public class AntiAirDataContainer
 {
     // These two are for the conversion in damage per second
     private const decimal ConstantDamageMultiplier = 1 / AntiAirAura.DamageInterval;

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/AntiAirDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/AntiAirDataContainer.cs
@@ -19,7 +19,7 @@ public class AntiAirDataContainer
 
     public AuraDataDataContainer? ShortRangeAura { get; set; }
 
-    public static AntiAirDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static AntiAirDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         if (ship.ShipClass.Equals(ShipClass.Submarine))
         {

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/AuraDataDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/AuraDataDataContainer.cs
@@ -4,7 +4,7 @@ using WoWsShipBuilder.DataElements.DataElementAttributes;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record AuraDataDataContainer : DataContainerBase
+public partial class AuraDataDataContainer : DataContainerBase
 {
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "KM")]
     public decimal Range { get; set; }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConcealmentDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConcealmentDataContainer.cs
@@ -7,7 +7,7 @@ using WoWsShipBuilder.DataStructures.Ship;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record ConcealmentDataContainer : DataContainerBase
+public partial class ConcealmentDataContainer : DataContainerBase
 {
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Sea", UnitKey = "KM")]
     public decimal ConcealmentBySea { get; set; }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConcealmentDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConcealmentDataContainer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataElements;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures;
@@ -27,7 +28,7 @@ public partial class ConcealmentDataContainer : DataContainerBase
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "KM")]
     public decimal FromSubsAtPeriscopeDepth { get; set; }
 
-    public static ConcealmentDataContainer FromShip(Ship ship, List<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static ConcealmentDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         var hull = ship.Hulls[shipConfiguration.First(upgrade => upgrade.UcType == ComponentType.Hull).Components[ComponentType.Hull][0]];
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConcealmentDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConcealmentDataContainer.cs
@@ -28,7 +28,7 @@ public partial class ConcealmentDataContainer : DataContainerBase
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "KM")]
     public decimal FromSubsAtPeriscopeDepth { get; set; }
 
-    public static ConcealmentDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static ConcealmentDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         var hull = ship.Hulls[shipConfiguration.First(upgrade => upgrade.UcType == ComponentType.Hull).Components[ComponentType.Hull][0]];
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConsumableDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConsumableDataContainer.cs
@@ -14,7 +14,7 @@ using WoWsShipBuilder.Infrastructure.Utility;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record ConsumableDataContainer : DataContainerBase
+public partial class ConsumableDataContainer : DataContainerBase
 {
     public string Name { get; set; } = default!;
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConsumableDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConsumableDataContainer.cs
@@ -36,7 +36,7 @@ public partial class ConsumableDataContainer : DataContainerBase
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
     public decimal WorkTime { get; set; }
 
-    public List<Modifier> Modifiers { get; set; } = null!;
+    public ImmutableList<Modifier> Modifiers { get; set; } = ImmutableList<Modifier>.Empty;
 
     public static ConsumableDataContainer FromTypeAndVariant(ShipConsumable consumable, ImmutableList<Modifier> modifiers, bool isCvPlanes, int shipHp, ShipClass shipClass)
     {
@@ -334,7 +334,7 @@ public partial class ConsumableDataContainer : DataContainerBase
             Cooldown = Math.Round(cooldown, 1),
             PreparationTime = Math.Round(prepTime, 1),
             WorkTime = Math.Round(workTime, 1),
-            Modifiers = consumableModifiers,
+            Modifiers = consumableModifiers.ToImmutableList(),
         };
 
         consumableDataContainer.UpdateDataElements();

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConsumableDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConsumableDataContainer.cs
@@ -208,14 +208,6 @@ public partial class ConsumableDataContainer : DataContainerBase
             // Hydro
             consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.TorpDetection.PCY016", "distTorpedo");
         }
-        else if (name.Contains("PCY009", StringComparison.InvariantCultureIgnoreCase) || name.Contains("PCY037", StringComparison.InvariantCultureIgnoreCase))
-        {
-            // TODO: fix these property names in data converter
-            // Damage Control Party, Damage Control Party (auto)
-            uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.PCY009.PCY037", uses);
-            cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY009.PCY037", cooldown);
-            workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY009.PCY037", workTime);
-        }
         else if (name.Contains("PCY014", StringComparison.InvariantCultureIgnoreCase))
         {
             // Smoke Generator
@@ -224,9 +216,9 @@ public partial class ConsumableDataContainer : DataContainerBase
         else if (name.Contains("PCY012", StringComparison.InvariantCultureIgnoreCase) || name.Contains("PCY038", StringComparison.InvariantCultureIgnoreCase))
         {
             // Fighter, Fighter (auto)
-            cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY012.PCY038", cooldown);
+            cooldown = modifiers.ApplyModifiers($"ConsumableDataContainer.Reload.{consumable.Index}", cooldown);
 
-            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.ExtraFighters.PCY012.PCY03", "fightersNum");
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, $"ConsumableDataContainer.ExtraFighters.{consumable.Index}", "fightersNum");
             var maxKills = consumableModifiers.First(x => x.Name.Equals("fightersNum", StringComparison.Ordinal)).Value;
 
             var plane = AppData.FindAircraft(consumable.PlaneName[..consumable.PlaneName.IndexOf('_', StringComparison.Ordinal)]);
@@ -256,7 +248,7 @@ public partial class ConsumableDataContainer : DataContainerBase
             consumableModifiers.Add(new("maxKills", maxKills, null, "ModifierConverter_MaxKillsAmount", Unit.None, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
 
             var concealment = (decimal)plane.ConcealmentFromShips;
-            var planesConcealment = (float)modifiers.ApplyModifiers("ConsumableDataContainer.Concealment.PCY012.PCY03", concealment);
+            var planesConcealment = (float)modifiers.ApplyModifiers($"ConsumableDataContainer.Concealment.{consumable.Index}", concealment);
             var oldConcealmentModifier = consumableModifiers.Find(x => x.Name.Equals("concealment", StringComparison.Ordinal));
             if (oldConcealmentModifier is not null)
             {

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConsumableDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConsumableDataContainer.cs
@@ -38,17 +38,17 @@ public partial class ConsumableDataContainer : DataContainerBase
 
     public List<Modifier> Modifiers { get; set; } = null!;
 
-    public static ConsumableDataContainer FromTypeAndVariant(ShipConsumable consumable, List<Modifier> modifiers, bool isCvPlanes, int shipHp, ShipClass shipClass)
+    public static ConsumableDataContainer FromTypeAndVariant(ShipConsumable consumable, ImmutableList<Modifier> modifiers, bool isCvPlanes, int shipHp, ShipClass shipClass)
     {
         return FromTypeAndVariant(consumable.ConsumableName, consumable.ConsumableVariantName, consumable.Slot, modifiers, isCvPlanes, shipHp, shipClass);
     }
 
-    public static ConsumableDataContainer FromTypeAndVariant(AircraftConsumable consumable, List<Modifier> modifiers, bool isCvPlanes, int shipHp, ShipClass shipClass)
+    public static ConsumableDataContainer FromTypeAndVariant(AircraftConsumable consumable, ImmutableList<Modifier> modifiers, bool isCvPlanes, int shipHp, ShipClass shipClass)
     {
         return FromTypeAndVariant(consumable.ConsumableName, consumable.ConsumableVariantName, consumable.Slot, modifiers, isCvPlanes, shipHp, shipClass);
     }
 
-    private static ConsumableDataContainer FromTypeAndVariant(string name, string variant, int slot, List<Modifier> modifiers, bool isCvPlanes, int shipHp, ShipClass shipClass)
+    private static ConsumableDataContainer FromTypeAndVariant(string name, string variant, int slot, ImmutableList<Modifier> modifiers, bool isCvPlanes, int shipHp, ShipClass shipClass)
     {
         var consumableIdentifier = $"{name} {variant}";
         var usingFallback = false;

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConsumableDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ConsumableDataContainer.cs
@@ -5,6 +5,7 @@ using WoWsShipBuilder.DataElements;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.DataStructures.Aircraft;
+using WoWsShipBuilder.DataStructures.Consumable;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
 using WoWsShipBuilder.Infrastructure.ApplicationData;
@@ -21,8 +22,6 @@ public partial class ConsumableDataContainer : DataContainerBase
     public string IconName { get; set; } = default!;
 
     public int Slot { get; set; }
-
-    public string Desc { get; set; } = default!;
 
     [DataElementType(DataElementTypes.KeyValue)]
     public string NumberOfUses { get; set; } = default!;
@@ -70,254 +69,16 @@ public partial class ConsumableDataContainer : DataContainerBase
 
         var iconName = string.IsNullOrEmpty(consumable.IconId) ? name : consumable.IconId;
         var localizationKey = string.IsNullOrEmpty(consumable.DescId) ? consumable.Name : consumable.DescId;
-        var consumableModifiers = consumable.Modifiers.ToList();
-        int uses = consumable.NumConsumables;
-        decimal cooldown = (decimal)consumable.ReloadTime;
-        decimal workTime = (decimal)consumable.WorkTime;
-        decimal prepTime = (decimal)consumable.PreparationTime;
+        var consumableModifiers = consumable.Modifiers;
+        var consumableState = new ConsumableState(name, consumable.NumConsumables, (decimal)consumable.ReloadTime, (decimal)consumable.WorkTime, iconName, localizationKey, consumableModifiers, (decimal)consumable.PreparationTime);
+
         if (isCvPlanes && !consumableModifiers.Exists(x => x.Name.Equals("error", StringComparison.Ordinal)))
         {
-            uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.Plane", uses);
-            cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.Plane", cooldown);
-            workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.Plane", workTime);
-
-            if (name.Contains("PCY036", StringComparison.InvariantCultureIgnoreCase))
-            {
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY036", workTime);
-
-                uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.PCY036", uses);
-
-                consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.PlaneRegenerationRate.PCY036", "regenerationRate");
-            }
-            else if (name.Contains("PCY035", StringComparison.InvariantCultureIgnoreCase))
-            {
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY035", workTime);
-
-                uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.PCY035", uses);
-
-                consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.Radius.PCY035", "radius");
-                consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.TimeDelayAttack.PCY035", "timeDelayAttack");
-                consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.TimeDelayAppear.PCY035", "timeFromHeaven");
-
-                var plane = AppData.FindAircraft(consumable.PlaneName[..consumable.PlaneName.IndexOf('_', StringComparison.Ordinal)]);
-                var oldCruisingSpeed = consumableModifiers.Find(x => x.Name.Equals("cruisingSpeed", StringComparison.Ordinal));
-                if (oldCruisingSpeed is not null)
-                {
-                    consumableModifiers.Remove(oldCruisingSpeed);
-                }
-
-                consumableModifiers.Add(new("cruisingSpeed", plane.Speed, null, "ShipStats_CruisingSpeed", Unit.Knots, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None ));
-
-                var oldConcealmentModifier = consumableModifiers.Find(x => x.Name.Equals("concealment", StringComparison.Ordinal));
-                if (oldConcealmentModifier is not null)
-                {
-                    consumableModifiers.Remove(oldConcealmentModifier);
-                }
-
-                consumableModifiers.Add(new("concealment", (float)plane.ConcealmentFromShips, null, "ShipStats_Concealment", Unit.Kilometers, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None ));
-
-                var fightersNum = consumableModifiers.First(x => x.Name.Equals("fightersNum", StringComparison.Ordinal)).Value;
-                var oldMaxKillModifier = consumableModifiers.Find(x => x.Name.Equals("maxKills", StringComparison.Ordinal));
-                if (oldMaxKillModifier is not null)
-                {
-                    consumableModifiers.Remove(oldMaxKillModifier);
-                }
-
-                consumableModifiers.Add(new("maxKills", fightersNum, null, "ModifierConverter_MaxKillsAmount", Unit.None, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.ToInt, ValueProcessingKind.None));
-
-                var baseMaxViewDistance = (decimal)plane.SpottingOnShips;
-                var maxViewDistance = (float)modifiers.ApplyModifiers("ConsumableDataContainer.Interceptor", baseMaxViewDistance);
-                var maxViewDistanceModifier = consumableModifiers.Find(x => x.Name.Equals("maxViewDistance"));
-
-                if (maxViewDistanceModifier is not null)
-                {
-                    consumableModifiers.Remove(maxViewDistanceModifier);
-                }
-
-                consumableModifiers.Add(new ("maxViewDistance", maxViewDistance, "", "ShipStats_MaxViewDistance", Unit.Kilometers, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
-
-                if (maxViewDistance == 0)
-                {
-                    iconName = $"{name}_Upgrade";
-                    localizationKey = $"{consumable.Name}_Upgrade";
-                }
-
-                consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.Concealment.PCY035", "concealment");
-            }
-            else if (name.Contains("PCY034", StringComparison.InvariantCultureIgnoreCase))
-            {
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY035", cooldown);
-            }
-            else if (name.Contains("PCY049", StringComparison.OrdinalIgnoreCase))
-            {
-                // Plane smoke generator
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY049", workTime);
-            }
+            consumableState = ProcessAircraftConsumable(consumableState, modifiers, consumable);
         }
         else if (!consumableModifiers.Exists(x => x.Name.Equals("error", StringComparison.Ordinal)))
         {
-            uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.Ship", uses);
-
-            cooldown = modifiers.ApplyModifiers($"ConsumableDataContainer.Reload.{shipClass.ShipClassToString()}", cooldown);
-            cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.Ship", cooldown);
-
-            workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.Ship", workTime);
-
-            if (name.Contains("PCY011", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Defensive AA
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY011", cooldown);
-
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY011", workTime);
-            }
-            else if (name.Contains("PCY013", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Spotting Aircraft
-                uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.PCY013", uses);
-
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY013", cooldown);
-
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY013", workTime);
-            }
-            else if (name.Contains("PCY010", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Repair party
-                uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.PCY010", uses);
-
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY010", cooldown);
-
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY010", workTime);
-
-                consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.RegenerationHpSpeed.PCY010", "consumable_regenerationHPSpeed");
-
-                var regenSpeed = consumableModifiers.First(x => x.Name.Equals("consumable_regenerationHPSpeed", StringComparison.Ordinal)).Value;
-                var hpPerHeal = (float)Math.Round(workTime * (decimal)(regenSpeed * shipHp));
-
-                var oldModifier = consumableModifiers.Find(x => x.Name.Equals("hpPerHeal", StringComparison.Ordinal));
-                if (oldModifier is not null)
-                {
-                    consumableModifiers.Remove(oldModifier);
-                }
-
-                consumableModifiers.Add(new("hpPerHeal", hpPerHeal, null, "Consumable_HpPerHeal", Unit.None, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
-            }
-            else if (name.Contains("PCY016", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Hydro
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY016", cooldown);
-
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY016", workTime);
-
-                consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.TorpDetection.PCY016", "distTorpedo");
-            }
-            else if (name.Contains("PCY020", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Radar
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY020", cooldown);
-
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY020", workTime);
-            }
-            else if (name.Contains("PCY009", StringComparison.InvariantCultureIgnoreCase) || name.Contains("PCY037", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Damage Control Party, Damage Control Party (auto)
-                uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.PCY009.PCY037", uses);
-
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY009.PCY037", cooldown);
-
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY009.PCY037", workTime);
-            }
-            else if (name.Contains("PCY014", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Smoke Generator
-                uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.PCY014", uses);
-
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY014", cooldown);
-
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY014", workTime);
-
-                consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.LifeTime.PCY014", "lifeTime");
-            }
-            else if (name.Contains("PCY015", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Engine Boost
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY015", cooldown);
-
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY015", workTime);
-            }
-            else if (name.Contains("PCY022", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Main Battery Reload Booster
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY022", cooldown);
-            }
-            else if (name.Contains("PCY012", StringComparison.InvariantCultureIgnoreCase) || name.Contains("PCY038", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Fighter, Fighter (auto)
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY012.PCY038", cooldown);
-
-                consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.ExtraFighters.PCY012.PCY03", "fightersNum");
-                var maxKills = consumableModifiers.First(x => x.Name.Equals("fightersNum", StringComparison.Ordinal)).Value;
-
-                var plane = AppData.FindAircraft(consumable.PlaneName[..consumable.PlaneName.IndexOf('_', StringComparison.Ordinal)]);
-
-                var oldCruisingModifier = consumableModifiers.Find(x => x.Name.Equals("cruisingSpeed", StringComparison.Ordinal));
-                if (oldCruisingModifier is not null)
-                {
-                    consumableModifiers.Remove(oldCruisingModifier);
-                }
-
-                consumableModifiers.Add(new("cruisingSpeed", plane.Speed, null, "ShipStats_CruisingSpeed", Unit.Knots, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
-
-                var oldMaxViewModifier = consumableModifiers.Find(x => x.Name.Equals("maxViewDistance", StringComparison.Ordinal));
-                if (oldMaxViewModifier is not null)
-                {
-                    consumableModifiers.Remove(oldMaxViewModifier);
-                }
-
-                consumableModifiers.Add(new("maxViewDistance", (float)plane.SpottingOnShips, null, "ShipStats_MaxViewDistance", Unit.Kilometers, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
-
-                var oldMaxKillsModifier = consumableModifiers.Find(x => x.Name.Equals("maxKills", StringComparison.Ordinal));
-                if (oldMaxKillsModifier is not null)
-                {
-                    consumableModifiers.Remove(oldMaxKillsModifier);
-                }
-
-                consumableModifiers.Add(new("maxKills", maxKills, null, "ModifierConverter_MaxKillsAmount", Unit.None, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
-
-                var concealment = (decimal)plane.ConcealmentFromShips;
-                var planesConcealment = (float)modifiers.ApplyModifiers("ConsumableDataContainer.Concealment.PCY012.PCY03", concealment);
-                var oldConcealmentModifier = consumableModifiers.Find(x => x.Name.Equals("concealment", StringComparison.Ordinal));
-                if (oldConcealmentModifier is not null)
-                {
-                    consumableModifiers.Remove(oldConcealmentModifier);
-                }
-
-                consumableModifiers.Add(new("concealment", planesConcealment, null, "ShipStats_Concealment", Unit.Kilometers, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
-            }
-            else if (name.Contains("PCY018", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Torpedo Reload Booster
-                uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.PCY018", uses);
-
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY018", cooldown);
-            }
-            else if (name.Contains("PCY045", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Hydrophone
-                // used prior to 13.1
-                consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.HydrophoneUpdateFrequency.PCY045", "hydrophoneUpdateFrequency");
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY045", cooldown);
-            }
-            else if (name.Contains("PCY048", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Submarine Surveillance
-                prepTime = modifiers.ApplyModifiers("ConsumableDataContainer.PrepTime.PCY048", prepTime);
-                cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY048", cooldown);
-            }
-            else if (name.Contains("PCY047", StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Reserve battery unit
-                workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY047", workTime);
-            }
+            consumableState = ProcessShipConsumable(consumableState, modifiers, consumable, shipClass, shipHp);
         }
         else if (usingFallback)
         {
@@ -326,18 +87,198 @@ public partial class ConsumableDataContainer : DataContainerBase
 
         var consumableDataContainer = new ConsumableDataContainer
         {
-            Name = localizationKey,
-            NumberOfUses = consumable.NumConsumables != -1 ? uses.ToString(CultureInfo.InvariantCulture) : "∞",
-            IconName = iconName,
+            Name = consumableState.LocalizationKey,
+            NumberOfUses = consumable.NumConsumables != -1 ? consumableState.Uses.ToString(CultureInfo.InvariantCulture) : "∞",
+            IconName = consumableState.IconName,
             Slot = slot,
-            Desc = "",
-            Cooldown = Math.Round(cooldown, 1),
-            PreparationTime = Math.Round(prepTime, 1),
-            WorkTime = Math.Round(workTime, 1),
-            Modifiers = consumableModifiers.ToImmutableList(),
+            Cooldown = Math.Round(consumableState.Cooldown, 1),
+            PreparationTime = Math.Round(consumableState.PrepTime, 1),
+            WorkTime = Math.Round(consumableState.WorkTime, 1),
+            Modifiers = consumableState.ConsumableModifiers,
         };
 
         consumableDataContainer.UpdateDataElements();
         return consumableDataContainer;
     }
+
+    private static ConsumableState ProcessAircraftConsumable(ConsumableState consumableState, ImmutableList<Modifier> modifiers, Consumable consumable)
+    {
+        var (name, uses, cooldown, workTime, iconName, localizationKey, consumableModifiersTmp, _) = consumableState;
+        var consumableModifiers = consumableModifiersTmp.ToList();
+
+        uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.Plane", uses);
+        cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.Plane", cooldown);
+        workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.Plane", workTime);
+
+        uses = modifiers.ApplyModifiers($"ConsumableDataContainer.Uses.{consumable.Index}", uses);
+        cooldown = modifiers.ApplyModifiers($"ConsumableDataContainer.Reload.{consumable.Index}", cooldown);
+        workTime = modifiers.ApplyModifiers($"ConsumableDataContainer.WorkTime.{consumable.Index}", workTime);
+
+        if (name.Contains("PCY036", StringComparison.InvariantCultureIgnoreCase))
+        {
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.PlaneRegenerationRate.PCY036", "regenerationRate");
+        }
+        else if (name.Contains("PCY035", StringComparison.InvariantCultureIgnoreCase))
+        {
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.Radius.PCY035", "radius");
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.TimeDelayAttack.PCY035", "timeDelayAttack");
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.TimeDelayAppear.PCY035", "timeFromHeaven");
+
+            var plane = AppData.FindAircraft(consumable.PlaneName[..consumable.PlaneName.IndexOf('_', StringComparison.Ordinal)]);
+            var oldCruisingSpeed = consumableModifiers.Find(x => x.Name.Equals("cruisingSpeed", StringComparison.Ordinal));
+            if (oldCruisingSpeed is not null)
+            {
+                consumableModifiers.Remove(oldCruisingSpeed);
+            }
+
+            consumableModifiers.Add(new("cruisingSpeed", plane.Speed, null, "ShipStats_CruisingSpeed", Unit.Knots, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
+
+            var oldConcealmentModifier = consumableModifiers.Find(x => x.Name.Equals("concealment", StringComparison.Ordinal));
+            if (oldConcealmentModifier is not null)
+            {
+                consumableModifiers.Remove(oldConcealmentModifier);
+            }
+
+            consumableModifiers.Add(new("concealment", (float)plane.ConcealmentFromShips, null, "ShipStats_Concealment", Unit.Kilometers, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
+
+            var fightersNum = consumableModifiers.First(x => x.Name.Equals("fightersNum", StringComparison.Ordinal)).Value;
+            var oldMaxKillModifier = consumableModifiers.Find(x => x.Name.Equals("maxKills", StringComparison.Ordinal));
+            if (oldMaxKillModifier is not null)
+            {
+                consumableModifiers.Remove(oldMaxKillModifier);
+            }
+
+            consumableModifiers.Add(new("maxKills", fightersNum, null, "ModifierConverter_MaxKillsAmount", Unit.None, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.ToInt, ValueProcessingKind.None));
+
+            var baseMaxViewDistance = (decimal)plane.SpottingOnShips;
+            var maxViewDistance = (float)modifiers.ApplyModifiers("ConsumableDataContainer.Interceptor", baseMaxViewDistance);
+            var maxViewDistanceModifier = consumableModifiers.Find(x => x.Name.Equals("maxViewDistance"));
+
+            if (maxViewDistanceModifier is not null)
+            {
+                consumableModifiers.Remove(maxViewDistanceModifier);
+            }
+
+            consumableModifiers.Add(new("maxViewDistance", maxViewDistance, "", "ShipStats_MaxViewDistance", Unit.Kilometers, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
+
+            if (maxViewDistance == 0)
+            {
+                iconName = $"{name}_Upgrade";
+                localizationKey = $"{consumable.Name}_Upgrade";
+            }
+
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.Concealment.PCY035", "concealment");
+        }
+
+        return consumableState with { Uses = uses, Cooldown = cooldown, WorkTime = workTime, IconName = iconName, LocalizationKey = localizationKey, ConsumableModifiers = consumableModifiers.ToImmutableList() };
+    }
+
+    private static ConsumableState ProcessShipConsumable(ConsumableState consumableState, ImmutableList<Modifier> modifiers, Consumable consumable, ShipClass shipClass, int shipHp)
+    {
+        var (name, uses, cooldown, workTime, iconName, localizationKey, consumableModifiersTmp, prepTime) = consumableState;
+        var consumableModifiers = consumableModifiersTmp.ToList();
+
+        uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.Ship", uses);
+        cooldown = modifiers.ApplyModifiers($"ConsumableDataContainer.Reload.{shipClass.ShipClassToString()}", cooldown);
+        cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.Ship", cooldown);
+        workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.Ship", workTime);
+
+        uses = modifiers.ApplyModifiers($"ConsumableDataContainer.Uses.{consumable.Index}", uses);
+        cooldown = modifiers.ApplyModifiers($"ConsumableDataContainer.Reload.{consumable.Index}", cooldown);
+        workTime = modifiers.ApplyModifiers($"ConsumableDataContainer.WorkTime.{consumable.Index}", workTime);
+
+        if (name.Contains("PCY010", StringComparison.InvariantCultureIgnoreCase))
+        {
+            // Repair party
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.RegenerationHpSpeed.PCY010", "consumable_regenerationHPSpeed");
+
+            var regenSpeed = consumableModifiers.First(x => x.Name.Equals("consumable_regenerationHPSpeed", StringComparison.Ordinal)).Value;
+            var hpPerHeal = (float)Math.Round(workTime * (decimal)(regenSpeed * shipHp));
+
+            var oldModifier = consumableModifiers.Find(x => x.Name.Equals("hpPerHeal", StringComparison.Ordinal));
+            if (oldModifier is not null)
+            {
+                consumableModifiers.Remove(oldModifier);
+            }
+
+            consumableModifiers.Add(new("hpPerHeal", hpPerHeal, null, "Consumable_HpPerHeal", Unit.None, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
+        }
+        else if (name.Contains("PCY016", StringComparison.InvariantCultureIgnoreCase))
+        {
+            // Hydro
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.TorpDetection.PCY016", "distTorpedo");
+        }
+        else if (name.Contains("PCY009", StringComparison.InvariantCultureIgnoreCase) || name.Contains("PCY037", StringComparison.InvariantCultureIgnoreCase))
+        {
+            // TODO: fix these property names in data converter
+            // Damage Control Party, Damage Control Party (auto)
+            uses = modifiers.ApplyModifiers("ConsumableDataContainer.Uses.PCY009.PCY037", uses);
+            cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY009.PCY037", cooldown);
+            workTime = modifiers.ApplyModifiers("ConsumableDataContainer.WorkTime.PCY009.PCY037", workTime);
+        }
+        else if (name.Contains("PCY014", StringComparison.InvariantCultureIgnoreCase))
+        {
+            // Smoke Generator
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.LifeTime.PCY014", "lifeTime");
+        }
+        else if (name.Contains("PCY012", StringComparison.InvariantCultureIgnoreCase) || name.Contains("PCY038", StringComparison.InvariantCultureIgnoreCase))
+        {
+            // Fighter, Fighter (auto)
+            cooldown = modifiers.ApplyModifiers("ConsumableDataContainer.Reload.PCY012.PCY038", cooldown);
+
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.ExtraFighters.PCY012.PCY03", "fightersNum");
+            var maxKills = consumableModifiers.First(x => x.Name.Equals("fightersNum", StringComparison.Ordinal)).Value;
+
+            var plane = AppData.FindAircraft(consumable.PlaneName[..consumable.PlaneName.IndexOf('_', StringComparison.Ordinal)]);
+
+            var oldCruisingModifier = consumableModifiers.Find(x => x.Name.Equals("cruisingSpeed", StringComparison.Ordinal));
+            if (oldCruisingModifier is not null)
+            {
+                consumableModifiers.Remove(oldCruisingModifier);
+            }
+
+            consumableModifiers.Add(new("cruisingSpeed", plane.Speed, null, "ShipStats_CruisingSpeed", Unit.Knots, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
+
+            var oldMaxViewModifier = consumableModifiers.Find(x => x.Name.Equals("maxViewDistance", StringComparison.Ordinal));
+            if (oldMaxViewModifier is not null)
+            {
+                consumableModifiers.Remove(oldMaxViewModifier);
+            }
+
+            consumableModifiers.Add(new("maxViewDistance", (float)plane.SpottingOnShips, null, "ShipStats_MaxViewDistance", Unit.Kilometers, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
+
+            var oldMaxKillsModifier = consumableModifiers.Find(x => x.Name.Equals("maxKills", StringComparison.Ordinal));
+            if (oldMaxKillsModifier is not null)
+            {
+                consumableModifiers.Remove(oldMaxKillsModifier);
+            }
+
+            consumableModifiers.Add(new("maxKills", maxKills, null, "ModifierConverter_MaxKillsAmount", Unit.None, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
+
+            var concealment = (decimal)plane.ConcealmentFromShips;
+            var planesConcealment = (float)modifiers.ApplyModifiers("ConsumableDataContainer.Concealment.PCY012.PCY03", concealment);
+            var oldConcealmentModifier = consumableModifiers.Find(x => x.Name.Equals("concealment", StringComparison.Ordinal));
+            if (oldConcealmentModifier is not null)
+            {
+                consumableModifiers.Remove(oldConcealmentModifier);
+            }
+
+            consumableModifiers.Add(new("concealment", planesConcealment, null, "ShipStats_Concealment", Unit.Kilometers, ImmutableHashSet<string>.Empty, DisplayValueProcessingKind.Raw, ValueProcessingKind.None));
+        }
+        else if (name.Contains("PCY045", StringComparison.InvariantCultureIgnoreCase))
+        {
+            // Hydrophone
+            // used prior to 13.1
+            consumableModifiers.UpdateConsumableModifierValue(modifiers, "ConsumableDataContainer.HydrophoneUpdateFrequency.PCY045", "hydrophoneUpdateFrequency");
+        }
+        else if (name.Contains("PCY048", StringComparison.InvariantCultureIgnoreCase))
+        {
+            // Submarine Surveillance
+            prepTime = modifiers.ApplyModifiers("ConsumableDataContainer.PrepTime.PCY048", prepTime);
+        }
+
+        return consumableState with { Uses = uses, Cooldown = cooldown, WorkTime = workTime, IconName = iconName, LocalizationKey = localizationKey, ConsumableModifiers = consumableModifiers.ToImmutableList(), PrepTime = prepTime };
+    }
+
+    private readonly record struct ConsumableState(string Name, int Uses, decimal Cooldown, decimal WorkTime, string IconName, string LocalizationKey, ImmutableList<Modifier> ConsumableModifiers, decimal PrepTime);
 }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ManeuverabilityDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ManeuverabilityDataContainer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataElements;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures;
@@ -59,7 +60,7 @@ public partial class ManeuverabilityDataContainer : DataContainerBase
     [DataElementFiltering(false)]
     public decimal EngineBlastProtection { get; set; }
 
-    public static ManeuverabilityDataContainer FromShip(Ship ship, List<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static ManeuverabilityDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         var hull = ship.Hulls[shipConfiguration.First(upgrade => upgrade.UcType == ComponentType.Hull).Components[ComponentType.Hull][0]];
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ManeuverabilityDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ManeuverabilityDataContainer.cs
@@ -7,7 +7,7 @@ using WoWsShipBuilder.DataStructures.Ship;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record ManeuverabilityDataContainer : DataContainerBase
+public partial class ManeuverabilityDataContainer : DataContainerBase
 {
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "Knots")]
     public decimal ManeuverabilityMaxSpeed { get; set; }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ManeuverabilityDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ManeuverabilityDataContainer.cs
@@ -60,7 +60,7 @@ public partial class ManeuverabilityDataContainer : DataContainerBase
     [DataElementFiltering(false)]
     public decimal EngineBlastProtection { get; set; }
 
-    public static ManeuverabilityDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static ManeuverabilityDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         var hull = ship.Hulls[shipConfiguration.First(upgrade => upgrade.UcType == ComponentType.Hull).Components[ComponentType.Hull][0]];
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ShipDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ShipDataContainer.cs
@@ -22,7 +22,7 @@ public record ShipDataContainer(string Index)
 
     public DepthChargesLauncherDataContainer? DepthChargeLauncherDataContainer { get; set; }
 
-    public List<CvAircraftDataContainer>? CvAircraftDataContainer { get; set; }
+    public ImmutableList<CvAircraftDataContainer>? CvAircraftDataContainer { get; set; }
 
     public ManeuverabilityDataContainer ManeuverabilityDataContainer { get; set; } = default!;
 
@@ -30,7 +30,7 @@ public record ShipDataContainer(string Index)
 
     public AntiAirDataContainer? AntiAirDataContainer { get; set; }
 
-    public List<object> SecondColumnContent { get; set; } = default!;
+    public ImmutableList<object> SecondColumnContent { get; set; } = ImmutableList<object>.Empty;
 
     public SpecialAbilityDataContainer? SpecialAbilityDataContainer { get; set; }
 
@@ -41,7 +41,7 @@ public record ShipDataContainer(string Index)
             // Main weapons
             MainBatteryDataContainer = MainBatteryDataContainer.FromShip(ship, shipConfiguration, modifiers),
             TorpedoArmamentDataContainer = TorpedoArmamentDataContainer.FromShip(ship, shipConfiguration, modifiers),
-            CvAircraftDataContainer = DataContainers.CvAircraftDataContainer.FromShip(ship, shipConfiguration, modifiers),
+            CvAircraftDataContainer = DataContainers.CvAircraftDataContainer.FromShip(ship, shipConfiguration, modifiers)?.ToImmutableList(),
             PingerGunDataContainer = PingerGunDataContainer.FromShip(ship, shipConfiguration, modifiers),
 
             // Secondary weapons
@@ -58,7 +58,7 @@ public record ShipDataContainer(string Index)
             SpecialAbilityDataContainer = SpecialAbilityDataContainer.FromShip(ship, shipConfiguration),
         };
 
-        shipDataContainer.SecondColumnContent = new List<object?>
+        var secondColumnContent = new List<object?>
             {
                 shipDataContainer.AntiAirDataContainer,
                 shipDataContainer.AirstrikeDataContainer,
@@ -70,8 +70,10 @@ public record ShipDataContainer(string Index)
 
         if (!shipDataContainer.SecondaryBatteryUiDataContainer.Secondaries.IsEmpty)
         {
-            shipDataContainer.SecondColumnContent.Insert(0, shipDataContainer.SecondaryBatteryUiDataContainer);
+            secondColumnContent.Insert(0, shipDataContainer.SecondaryBatteryUiDataContainer);
         }
+
+        shipDataContainer.SecondColumnContent = secondColumnContent.ToImmutableList();
 
         return shipDataContainer;
     }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ShipDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ShipDataContainer.cs
@@ -67,7 +67,7 @@ public record ShipDataContainer(string Index)
             .Cast<object>()
             .ToList();
 
-        if (shipDataContainer.SecondaryBatteryUiDataContainer.Secondaries != null)
+        if (!shipDataContainer.SecondaryBatteryUiDataContainer.Secondaries.IsEmpty)
         {
             shipDataContainer.SecondColumnContent.Insert(0, shipDataContainer.SecondaryBatteryUiDataContainer);
         }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ShipDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ShipDataContainer.cs
@@ -4,8 +4,10 @@ using WoWsShipBuilder.DataStructures.Ship;
 
 namespace WoWsShipBuilder.Features.DataContainers;
 
-public record ShipDataContainer(string Index)
+public class ShipDataContainer(string index)
 {
+    public string Index { get; } = index;
+
     public SurvivabilityDataContainer SurvivabilityDataContainer { get; set; } = default!;
 
     public MainBatteryDataContainer? MainBatteryDataContainer { get; set; }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ShipDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ShipDataContainer.cs
@@ -34,7 +34,7 @@ public record ShipDataContainer(string Index)
 
     public SpecialAbilityDataContainer? SpecialAbilityDataContainer { get; set; }
 
-    public static ShipDataContainer CreateFromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static ShipDataContainer CreateFromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         var shipDataContainer = new ShipDataContainer(ship.Index)
         {
@@ -55,7 +55,7 @@ public record ShipDataContainer(string Index)
             ManeuverabilityDataContainer = ManeuverabilityDataContainer.FromShip(ship, shipConfiguration, modifiers),
             ConcealmentDataContainer = ConcealmentDataContainer.FromShip(ship, shipConfiguration, modifiers),
             SurvivabilityDataContainer = SurvivabilityDataContainer.FromShip(ship, shipConfiguration, modifiers),
-            SpecialAbilityDataContainer = SpecialAbilityDataContainer.FromShip(ship, shipConfiguration, modifiers),
+            SpecialAbilityDataContainer = SpecialAbilityDataContainer.FromShip(ship, shipConfiguration),
         };
 
         shipDataContainer.SecondColumnContent = new List<object?>

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/ShipDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/ShipDataContainer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
 
@@ -33,7 +34,7 @@ public record ShipDataContainer(string Index)
 
     public SpecialAbilityDataContainer? SpecialAbilityDataContainer { get; set; }
 
-    public static ShipDataContainer CreateFromShip(Ship ship, List<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static ShipDataContainer CreateFromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         var shipDataContainer = new ShipDataContainer(ship.Index)
         {

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/SpecialAbilityDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/SpecialAbilityDataContainer.cs
@@ -51,7 +51,7 @@ public partial class SpecialAbilityDataContainer : DataContainerBase
 
     public bool IsBurstMode { get; set; }
 
-    public static SpecialAbilityDataContainer? FromShip(Ship ship, List<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static SpecialAbilityDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         SpecialAbilityDataContainer specialDataContainer;
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/SpecialAbilityDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/SpecialAbilityDataContainer.cs
@@ -51,7 +51,7 @@ public partial class SpecialAbilityDataContainer : DataContainerBase
 
     public bool IsBurstMode { get; set; }
 
-    public static SpecialAbilityDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static SpecialAbilityDataContainer? FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration)
     {
         SpecialAbilityDataContainer specialDataContainer;
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/SpecialAbilityDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/SpecialAbilityDataContainer.cs
@@ -10,7 +10,7 @@ using WoWsShipBuilder.DataStructures.Ship;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record SpecialAbilityDataContainer : DataContainerBase
+public partial class SpecialAbilityDataContainer : DataContainerBase
 {
     public string Name { get; set; } = default!;
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/SpecialAbilityDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/SpecialAbilityDataContainer.cs
@@ -47,7 +47,7 @@ public partial class SpecialAbilityDataContainer : DataContainerBase
 
     // This is in common
     [JsonIgnore]
-    public List<Modifier> Modifiers { get; set; } = null!;
+    public ImmutableList<Modifier> Modifiers { get; set; } = ImmutableList<Modifier>.Empty;
 
     public bool IsBurstMode { get; set; }
 
@@ -69,7 +69,7 @@ public partial class SpecialAbilityDataContainer : DataContainerBase
                 InactivityDelay = (decimal)specialAbility.DecrementDelay,
                 ProgressLossInterval = (decimal)specialAbility.DecrementPeriod,
                 ProgressLossPerInterval = (decimal)specialAbility.DecrementCount,
-                Modifiers = specialAbility.Modifiers.ToList(),
+                Modifiers = specialAbility.Modifiers,
             };
 
             specialDataContainer.UpdateDataElements();
@@ -109,7 +109,7 @@ public partial class SpecialAbilityDataContainer : DataContainerBase
                 ReloadDuringBurst = burstMode.ReloadDuringBurst,
                 ReloadAfterBurst = burstMode.ReloadAfterBurst,
                 ShotInBurst = burstMode.ShotInBurst,
-                Modifiers = burstMode.Modifiers.ToList(),
+                Modifiers = burstMode.Modifiers,
                 IsBurstMode = true,
             };
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/SurvivabilityDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/SurvivabilityDataContainer.cs
@@ -93,7 +93,7 @@ public partial class SurvivabilityDataContainer : DataContainerBase
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Flooding", UnitKey = "PerCent")]
     public decimal FloodTorpedoProtection { get; set; }
 
-    public static SurvivabilityDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static SurvivabilityDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, ImmutableList<Modifier> modifiers)
     {
         Hull shipHull = ship.Hulls[shipConfiguration.First(upgrade => upgrade.UcType == ComponentType.Hull).Components[ComponentType.Hull].First()];
 

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/SurvivabilityDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/SurvivabilityDataContainer.cs
@@ -10,7 +10,7 @@ using WoWsShipBuilder.Infrastructure.Utility;
 namespace WoWsShipBuilder.Features.DataContainers;
 
 [DataContainer]
-public partial record SurvivabilityDataContainer : DataContainerBase
+public partial class SurvivabilityDataContainer : DataContainerBase
 {
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "HP", LocalizationKeyOverride = "ShipHp")]
     public int HitPoints { get; set; }

--- a/WoWsShipBuilder.Common/Features/DataContainers/Ship/SurvivabilityDataContainer.cs
+++ b/WoWsShipBuilder.Common/Features/DataContainers/Ship/SurvivabilityDataContainer.cs
@@ -1,11 +1,11 @@
 // ReSharper disable InconsistentNaming
 
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataElements;
 using WoWsShipBuilder.DataElements.DataElementAttributes;
 using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
-using WoWsShipBuilder.Infrastructure.Utility;
 
 namespace WoWsShipBuilder.Features.DataContainers;
 
@@ -93,7 +93,7 @@ public partial class SurvivabilityDataContainer : DataContainerBase
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "Flooding", UnitKey = "PerCent")]
     public decimal FloodTorpedoProtection { get; set; }
 
-    public static SurvivabilityDataContainer FromShip(Ship ship, List<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
+    public static SurvivabilityDataContainer FromShip(Ship ship, ImmutableList<ShipUpgrade> shipConfiguration, List<Modifier> modifiers)
     {
         Hull shipHull = ship.Hulls[shipConfiguration.First(upgrade => upgrade.UcType == ComponentType.Hull).Components[ComponentType.Hull].First()];
 

--- a/WoWsShipBuilder.Common/Features/Navigation/ShipBuildContainer.cs
+++ b/WoWsShipBuilder.Common/Features/Navigation/ShipBuildContainer.cs
@@ -1,15 +1,16 @@
-﻿using WoWsShipBuilder.DataStructures.Modifiers;
+﻿using System.Collections.Immutable;
+using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
 using WoWsShipBuilder.Features.Builds;
 using WoWsShipBuilder.Features.DataContainers;
 
 namespace WoWsShipBuilder.Features.Navigation;
 
-public sealed record ShipBuildContainer(Ship Ship, Build? Build, Guid Id, IEnumerable<int>? ActivatedConsumableSlots, bool SpecialAbilityActive, ShipDataContainer? ShipDataContainer, List<Modifier>? Modifiers)
+public sealed record ShipBuildContainer(Ship Ship, Build? Build, Guid Id, ImmutableArray<int> ActivatedConsumableSlots, bool SpecialAbilityActive, ShipDataContainer? ShipDataContainer, ImmutableList<Modifier> Modifiers)
 {
-    public static ShipBuildContainer CreateNew(Ship ship, Build? build, IEnumerable<int>? activatedConsumableSlots, bool specialAbilityActive = false)
+    public static ShipBuildContainer CreateNew(Ship ship, Build? build, ImmutableArray<int> activatedConsumableSlots, bool specialAbilityActive = false)
     {
-        return new(ship, build, Guid.NewGuid(), activatedConsumableSlots, specialAbilityActive, null, null);
+        return new(ship, build, Guid.NewGuid(), activatedConsumableSlots, specialAbilityActive, null, ImmutableList<Modifier>.Empty);
     }
 
     /// <summary>
@@ -45,13 +46,13 @@ public sealed record ShipBuildContainer(Ship Ship, Build? Build, Guid Id, IEnume
             return false;
         }
 
-        if ((this.ActivatedConsumableSlots is null && newContainer.ActivatedConsumableSlots is not null) || (this.ActivatedConsumableSlots is not null && newContainer.ActivatedConsumableSlots is null))
+        if ((this.ActivatedConsumableSlots.IsEmpty && !newContainer.ActivatedConsumableSlots.IsEmpty) || (!this.ActivatedConsumableSlots.IsEmpty && newContainer.ActivatedConsumableSlots.IsEmpty))
         {
             return false;
         }
 
-        IOrderedEnumerable<int> oldConsumables = (this.ActivatedConsumableSlots ?? Enumerable.Empty<int>()).OrderBy(i => i);
-        IOrderedEnumerable<int> newConsumables = (newContainer.ActivatedConsumableSlots ?? Enumerable.Empty<int>()).OrderBy(i => i);
+        IOrderedEnumerable<int> oldConsumables = this.ActivatedConsumableSlots.OrderBy(i => i);
+        IOrderedEnumerable<int> newConsumables = newContainer.ActivatedConsumableSlots.OrderBy(i => i);
         return oldConsumables.SequenceEqual(newConsumables);
     }
 }

--- a/WoWsShipBuilder.Common/Features/ShipComparison/GridData/SecondaryGridDataWrapper.cs
+++ b/WoWsShipBuilder.Common/Features/ShipComparison/GridData/SecondaryGridDataWrapper.cs
@@ -5,37 +5,37 @@ namespace WoWsShipBuilder.Features.ShipComparison.GridData;
 
 public class SecondaryGridDataWrapper
 {
-    public SecondaryGridDataWrapper(IReadOnlyCollection<SecondaryBatteryDataContainer>? secondaryBattery)
+    public SecondaryGridDataWrapper(IReadOnlyCollection<SecondaryBatteryDataContainer> secondaryBattery)
     {
         // Secondaries
-        this.Caliber = secondaryBattery?.Select(x => x.GunCaliber).ToNoSortList() ?? new();
-        this.BarrelCount = secondaryBattery?.Select(x => x.BarrelsCount).ToNoSortList() ?? new();
-        this.BarrelsLayout = secondaryBattery?.Select(x => x.BarrelsLayout).ToNoSortList() ?? new();
-        this.Range = secondaryBattery?.Select(x => x.Range).First();
-        this.Reload = secondaryBattery?.Select(x => x.Reload).ToNoSortList() ?? new();
-        this.RoF = secondaryBattery?.Select(x => x.RoF).ToNoSortList() ?? new();
-        this.Dpm = secondaryBattery?.Select(x => x.TheoreticalDpm).ToNoSortList() ?? new();
-        this.Fpm = secondaryBattery?.Select(x => x.PotentialFpm).ToNoSortList() ?? new();
-        this.Sigma = secondaryBattery?.Select(x => x.Sigma).First();
-        this.DispersionData = secondaryBattery?.Select(x => x.DispersionData).ToList() ?? new();
-        this.DispersionModifier = secondaryBattery?.Select(x => x.DispersionModifier).ToList() ?? new();
+        this.Caliber = secondaryBattery.Select(x => x.GunCaliber).ToNoSortList();
+        this.BarrelCount = secondaryBattery.Select(x => x.BarrelsCount).ToNoSortList();
+        this.BarrelsLayout = secondaryBattery.Select(x => x.BarrelsLayout).ToNoSortList();
+        this.Range = secondaryBattery.Select(x => x.Range).FirstOrDefault();
+        this.Reload = secondaryBattery.Select(x => x.Reload).ToNoSortList();
+        this.RoF = secondaryBattery.Select(x => x.RoF).ToNoSortList();
+        this.Dpm = secondaryBattery.Select(x => x.TheoreticalDpm).ToNoSortList();
+        this.Fpm = secondaryBattery.Select(x => x.PotentialFpm).ToNoSortList();
+        this.Sigma = secondaryBattery.Select(x => x.Sigma).FirstOrDefault();
+        this.DispersionData = secondaryBattery.Select(x => x.DispersionData).ToList();
+        this.DispersionModifier = secondaryBattery.Select(x => x.DispersionModifier).ToList();
 
         // Secondary shells
-        var secondaryShellData = secondaryBattery?.Select(x => x.Shell).ToList();
+        var secondaryShellData = secondaryBattery.Select(x => x.Shell).ToList();
 
-        this.Type = secondaryShellData?.Select(x => x?.Type).First();
-        this.Mass = secondaryShellData?.Select(x => x?.Mass ?? 0).ToNoSortList() ?? new();
-        this.Damage = secondaryShellData?.Select(x => x?.Damage ?? 0).ToNoSortList() ?? new();
-        this.SplashRadius = secondaryShellData?.Select(x => x?.SplashRadius ?? 0).ToNoSortList() ?? new();
-        this.SplashDamage = secondaryShellData?.Select(x => x?.SplashDmg ?? 0).ToNoSortList() ?? new();
-        this.Penetration = secondaryShellData?.Select(x => x?.Penetration ?? 0).ToNoSortList() ?? new();
-        this.Speed = secondaryShellData?.Select(x => x?.ShellVelocity ?? 0).ToNoSortList() ?? new();
-        this.AirDrag = secondaryShellData?.Select(x => x?.AirDrag ?? 0).ToNoSortList() ?? new();
-        this.HeShellFireChance = secondaryShellData?.Select(x => x?.ShellFireChance ?? 0).ToNoSortList() ?? new();
-        this.HeBlastRadius = secondaryShellData?.Select(x => x?.ExplosionRadius ?? 0).ToNoSortList() ?? new();
-        this.HeBlastPenetration = secondaryShellData?.Select(x => x?.SplashCoeff ?? 0).ToNoSortList() ?? new();
-        this.SapOvermatch = secondaryShellData?.Select(x => x?.Overmatch ?? 0).ToNoSortList() ?? new();
-        this.SapRicochet = secondaryShellData?.Select(x => x?.RicochetAngles ?? default!).ToNoSortList() ?? new();
+        this.Type = secondaryShellData.Select(x => x?.Type).FirstOrDefault();
+        this.Mass = secondaryShellData.Select(x => x?.Mass ?? 0).ToNoSortList();
+        this.Damage = secondaryShellData.Select(x => x?.Damage ?? 0).ToNoSortList();
+        this.SplashRadius = secondaryShellData.Select(x => x?.SplashRadius ?? 0).ToNoSortList();
+        this.SplashDamage = secondaryShellData.Select(x => x?.SplashDmg ?? 0).ToNoSortList();
+        this.Penetration = secondaryShellData.Select(x => x?.Penetration ?? 0).ToNoSortList();
+        this.Speed = secondaryShellData.Select(x => x?.ShellVelocity ?? 0).ToNoSortList();
+        this.AirDrag = secondaryShellData.Select(x => x?.AirDrag ?? 0).ToNoSortList();
+        this.HeShellFireChance = secondaryShellData.Select(x => x?.ShellFireChance ?? 0).ToNoSortList();
+        this.HeBlastRadius = secondaryShellData.Select(x => x?.ExplosionRadius ?? 0).ToNoSortList();
+        this.HeBlastPenetration = secondaryShellData.Select(x => x?.SplashCoeff ?? 0).ToNoSortList();
+        this.SapOvermatch = secondaryShellData.Select(x => x?.Overmatch ?? 0).ToNoSortList();
+        this.SapRicochet = secondaryShellData.Select(x => x?.RicochetAngles ?? default!).ToNoSortList();
     }
 
     public NoSortList<decimal> Caliber { get; }

--- a/WoWsShipBuilder.Common/Features/ShipComparison/GridData/TorpedoBomberGridDataWrapper.cs
+++ b/WoWsShipBuilder.Common/Features/ShipComparison/GridData/TorpedoBomberGridDataWrapper.cs
@@ -1,4 +1,5 @@
-﻿using WoWsShipBuilder.DataStructures;
+﻿using System.Collections.Immutable;
+using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.Features.DataContainers;
 
 namespace WoWsShipBuilder.Features.ShipComparison.GridData;
@@ -45,7 +46,7 @@ public class TorpedoBomberGridDataWrapper : PlaneGridDataWrapper
         this.WeaponFloodingChance = aerialTorpedoes?.Select(x => x?.FloodingChance ?? 0).ToNoSortList() ?? new();
         this.WeaponBlastRadius = aerialTorpedoes?.Select(x => x?.ExplosionRadius ?? 0).ToNoSortList() ?? new();
         this.WeaponBlastPenetration = aerialTorpedoes?.Select(x => x?.SplashCoeff ?? 0).ToNoSortList() ?? new();
-        this.WeaponCanHit = aerialTorpedoes?.Select(x => x?.CanHitClasses).ToNoSortList() ?? new();
+        this.WeaponCanHit = aerialTorpedoes?.Select(x => x?.CanHitClasses ?? ImmutableList<ShipClass>.Empty).ToNoSortList() ?? new();
     }
 
     public NoSortList<string> WeaponType { get; }
@@ -68,5 +69,5 @@ public class TorpedoBomberGridDataWrapper : PlaneGridDataWrapper
 
     public NoSortList<decimal> WeaponBlastPenetration { get; }
 
-    public NoSortList<List<ShipClass>?> WeaponCanHit { get; }
+    public NoSortList<ImmutableList<ShipClass>> WeaponCanHit { get; }
 }

--- a/WoWsShipBuilder.Common/Features/ShipComparison/GridData/TorpedoGridDataWrapper.cs
+++ b/WoWsShipBuilder.Common/Features/ShipComparison/GridData/TorpedoGridDataWrapper.cs
@@ -1,4 +1,5 @@
-﻿using WoWsShipBuilder.DataStructures;
+﻿using System.Collections.Immutable;
+using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.Features.DataContainers;
 
 namespace WoWsShipBuilder.Features.ShipComparison.GridData;
@@ -7,7 +8,7 @@ public class TorpedoGridDataWrapper
 {
     public TorpedoGridDataWrapper(TorpedoArmamentDataContainer? torpedoArmament)
     {
-        List<TorpedoDataContainer>? torpedoes = torpedoArmament?.Torpedoes;
+        var torpedoes = torpedoArmament?.Torpedoes;
 
         this.FullSalvoDamage = new() { torpedoArmament?.FullSalvoDamage, torpedoArmament?.TorpFullSalvoDmg, torpedoArmament?.AltTorpFullSalvoDmg };
         this.Type = torpedoes?.Select(x => x.TorpedoType).ToNoSortList() ?? new();
@@ -45,5 +46,5 @@ public class TorpedoGridDataWrapper
 
     public NoSortList<decimal> BlastPenetration { get; }
 
-    public NoSortList<List<ShipClass>?> CanHit { get; }
+    public NoSortList<ImmutableList<ShipClass>> CanHit { get; }
 }

--- a/WoWsShipBuilder.Common/Features/ShipComparison/GridSections/AerialTorpedoesFragment.razor
+++ b/WoWsShipBuilder.Common/Features/ShipComparison/GridSections/AerialTorpedoesFragment.razor
@@ -294,15 +294,15 @@
             </CellTemplate>
         </TemplateColumn>
 
-        <TemplateColumn ID="@($"{dataSectionString}_{columnTitleCanHit}")" Hidden="@element.IsColumnHidden.Invoke(dataSectionString, columnTitleCanHit)" T="GridDataWrapper" Title="@columnTitleCanHit" HeaderClass="column-text-center" CellClass="column-text-center" SortBy="@(x=> !x.TorpedoBombers.WeaponCanHit.Any() ? 0 : x.TorpedoBombers.WeaponCanHit.First()?.Count ?? (x.TorpedoBombers.WeaponDamage.Any() ? 5 : 0))">
+        <TemplateColumn ID="@($"{dataSectionString}_{columnTitleCanHit}")" Hidden="@element.IsColumnHidden.Invoke(dataSectionString, columnTitleCanHit)" T="GridDataWrapper" Title="@columnTitleCanHit" HeaderClass="column-text-center" CellClass="column-text-center" SortBy="@(x=> !x.TorpedoBombers.WeaponCanHit.Any() ? 0 : x.TorpedoBombers.WeaponCanHit.First().Count)">
             <CellTemplate>
                 @if (context.Item.TorpedoBombers.WeaponCanHit.Any())
                 {
-                    List<List<ShipClass>?> torps = context.Item.TorpedoBombers.WeaponCanHit;
+                    var torps = context.Item.TorpedoBombers.WeaponCanHit;
                     for (var i = 0; i < torps.Count; i++)
                     {
-                        List<ShipClass>? classes = torps[i];
-                        if (classes is null && context.Item.TorpedoBombers.WeaponDamage.Any())
+                        var classes = torps[i];
+                        if (classes.IsEmpty && context.Item.TorpedoBombers.WeaponDamage.Any())
                         {
                             <MudStack row Justify="Justify.Center" AlignItems="AlignItems.Center">
                                 @foreach (var shipClass in Enum.GetValues(typeof(ShipClass)).Cast<ShipClass>().ToList())
@@ -311,11 +311,11 @@
                                 }
                             </MudStack>
                         }
-                        else if (classes is null && !context.Item.TorpedoBombers.WeaponDamage.Any())
+                        else if (classes.IsEmpty && !context.Item.TorpedoBombers.WeaponDamage.Any())
                         {
                             @UtilityFragments.DataNotAvailableFragment
                         }
-                        else if (classes is not null)
+                        else if (!classes.IsEmpty)
                         {
                             <MudStack Row Justify="Justify.Center" AlignItems="AlignItems.Center">
                                 @foreach (var shipClass in classes)

--- a/WoWsShipBuilder.Common/Features/ShipComparison/GridSections/TorpedoesFragment.razor
+++ b/WoWsShipBuilder.Common/Features/ShipComparison/GridSections/TorpedoesFragment.razor
@@ -227,7 +227,7 @@
         <TemplateColumn ID="@($"{dataSectionString}_{columnTitleSalvoDamage}")" Hidden="@element.IsColumnHidden.Invoke(dataSectionString, columnTitleSalvoDamage)" T="GridDataWrapper" Title="@columnTitleSalvoDamage" HeaderClass="column-text-center" CellClass="column-text-center" SortBy="@(x => x.Torpedo.FullSalvoDamage.Where(y => !string.IsNullOrEmpty(y)).Select(z => int.Parse(z ?? "0", NumberStyles.AllowThousands, nfi)).ToNoSortList())">
             <CellTemplate>
                 @{
-                   List<string?> torps = context.Item.Torpedo.FullSalvoDamage.Where(x => !string.IsNullOrEmpty(x)).ToList();
+                   var torps = context.Item.Torpedo.FullSalvoDamage.Where(x => !string.IsNullOrEmpty(x)).ToList();
                    if (torps.Count == 0)
                    {
                        @UtilityFragments.DataNotAvailableFragment
@@ -442,15 +442,15 @@
             </CellTemplate>
         </TemplateColumn>
 
-        <TemplateColumn ID="@($"{dataSectionString}_{columnTitleCanHit}")" Hidden="@element.IsColumnHidden.Invoke(dataSectionString, columnTitleCanHit)" T="GridDataWrapper" Title="@columnTitleCanHit" HeaderClass="column-text-center" CellClass="column-text-center" SortBy="@(x=> !x.Torpedo.CanHit.Any() ? 0 : x.Torpedo.CanHit.First()?.Count ?? (x.Torpedo.Damage.Any() ? 5 : 0))">
+        <TemplateColumn ID="@($"{dataSectionString}_{columnTitleCanHit}")" Hidden="@element.IsColumnHidden.Invoke(dataSectionString, columnTitleCanHit)" T="GridDataWrapper" Title="@columnTitleCanHit" HeaderClass="column-text-center" CellClass="column-text-center" SortBy="@(x=> !x.Torpedo.CanHit.Any() ? 0 : x.Torpedo.CanHit.First().Count)">
             <CellTemplate>
                 @if (context.Item.Torpedo.CanHit.Any())
                 {
-                    List<List<ShipClass>?> torps = context.Item.Torpedo.CanHit;
+                    var torps = context.Item.Torpedo.CanHit;
                     for (var i = 0; i < torps.Count; i++)
                     {
-                        List<ShipClass>? classes = torps[i];
-                        if (classes is null && context.Item.Torpedo.Damage.Any())
+                        var classes = torps[i];
+                        if (classes.IsEmpty && context.Item.Torpedo.Damage.Any())
                         {
                             <MudStack row Justify="Justify.Center" AlignItems="AlignItems.Center">
                                 @foreach (var shipClass in Enum.GetValues(typeof(ShipClass)).Cast<ShipClass>().ToList())
@@ -459,11 +459,11 @@
                                 }
                             </MudStack>
                         }
-                        else if (classes is null && !context.Item.Torpedo.Damage.Any())
+                        else if (classes.IsEmpty && !context.Item.Torpedo.Damage.Any())
                         {
                             @UtilityFragments.DataNotAvailableFragment
                         }
-                        else if (classes is not null)
+                        else if (!classes.IsEmpty)
                         {
                             <MudStack Row Justify="Justify.Center" AlignItems="AlignItems.Center">
                                 @foreach (var shipClass in classes)

--- a/WoWsShipBuilder.Common/Features/ShipComparison/ShipComparisonViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/ShipComparison/ShipComparisonViewModel.cs
@@ -598,8 +598,8 @@ public partial class ShipComparisonViewModel : ReactiveObject
             ShipComparisonDataSections.Bombers => list.Where(x => x.Value.Bombers.Type.Any()).ToDictionary(x => x.Key, x => x.Value),
             ShipComparisonDataSections.Bombs => list.Where(x => x.Value.Bombers.WeaponType.Any()).ToDictionary(x => x.Key, x => x.Value),
             ShipComparisonDataSections.Sonar => list.Where(x => x.Value.ShipDataContainer.PingerGunDataContainer is not null).ToDictionary(x => x.Key, x => x.Value),
-            ShipComparisonDataSections.SecondaryBattery => list.Where(x => x.Value.ShipDataContainer.SecondaryBatteryUiDataContainer.Secondaries is not null).ToDictionary(x => x.Key, x => x.Value),
-            ShipComparisonDataSections.SecondaryBatteryShells => list.Where(x => x.Value.ShipDataContainer.SecondaryBatteryUiDataContainer.Secondaries is not null).ToDictionary(x => x.Key, x => x.Value),
+            ShipComparisonDataSections.SecondaryBattery => list.Where(x => !x.Value.ShipDataContainer.SecondaryBatteryUiDataContainer.Secondaries.IsEmpty).ToDictionary(x => x.Key, x => x.Value),
+            ShipComparisonDataSections.SecondaryBatteryShells => list.Where(x => !x.Value.ShipDataContainer.SecondaryBatteryUiDataContainer.Secondaries.IsEmpty).ToDictionary(x => x.Key, x => x.Value),
             ShipComparisonDataSections.AntiAir => list.Where(x => x.Value.ShipDataContainer.AntiAirDataContainer is not null).ToDictionary(x => x.Key, x => x.Value),
             ShipComparisonDataSections.AirStrike => list.Where(x => x.Value.ShipDataContainer.AirstrikeDataContainer is not null).ToDictionary(x => x.Key, x => x.Value),
             ShipComparisonDataSections.Asw => list.Where(x => x.Value.ShipDataContainer.AswAirstrikeDataContainer is not null || x.Value.ShipDataContainer.DepthChargeLauncherDataContainer is not null).ToDictionary(x => x.Key, x => x.Value),
@@ -639,8 +639,8 @@ public partial class ShipComparisonViewModel : ReactiveObject
                 case ShipComparisonDataSections.Torpedo when !displayedShips.Any(x => x.Value.ShipDataContainer.TorpedoArmamentDataContainer is not null):
                     dataSections.Remove(dataSection);
                     break;
-                case ShipComparisonDataSections.SecondaryBattery when !displayedShips.Any(x => x.Value.ShipDataContainer.SecondaryBatteryUiDataContainer.Secondaries is not null):
-                case ShipComparisonDataSections.SecondaryBatteryShells when !displayedShips.Any(x => x.Value.ShipDataContainer.SecondaryBatteryUiDataContainer.Secondaries is not null):
+                case ShipComparisonDataSections.SecondaryBattery when displayedShips.All(x => x.Value.ShipDataContainer.SecondaryBatteryUiDataContainer.Secondaries.IsEmpty):
+                case ShipComparisonDataSections.SecondaryBatteryShells when displayedShips.All(x => x.Value.ShipDataContainer.SecondaryBatteryUiDataContainer.Secondaries.IsEmpty):
                     dataSections.Remove(dataSection);
                     break;
                 case ShipComparisonDataSections.AntiAir when !displayedShips.Any(x => x.Value.ShipDataContainer.AntiAirDataContainer is not null):

--- a/WoWsShipBuilder.Common/Features/ShipComparison/ShipComparisonViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/ShipComparison/ShipComparisonViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using DynamicData;
@@ -556,19 +557,19 @@ public partial class ShipComparisonViewModel : ReactiveObject
         this.EditBuilds(this.FilteredShipList.Where(x => x.Value.Build is null).ToDictionary(x => x.Key, x => this.ResetBuild(x.Value)));
     }
 
-    private List<ShipUpgrade> GetShipConfiguration(Ship ship)
+    private ImmutableList<ShipUpgrade> GetShipConfiguration(Ship ship)
     {
         var shipConfiguration = this.UseUpgradedModules
             ? ShipModuleHelper.GroupAndSortUpgrades(ship.ShipUpgradeInfo.ShipUpgrades)
                 .OrderBy(entry => entry.Key)
                 .Select(entry => entry.Value)
                 .Select(module => module[^1])
-                .ToList()
+                .ToImmutableList()
             : ShipModuleHelper.GroupAndSortUpgrades(ship.ShipUpgradeInfo.ShipUpgrades)
                 .OrderBy(entry => entry.Key)
                 .Select(entry => entry.Value)
                 .Select(module => module[0])
-                .ToList();
+                .ToImmutableList();
         return shipConfiguration;
     }
 

--- a/WoWsShipBuilder.Common/Features/ShipComparison/ShipComparisonViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/ShipComparison/ShipComparisonViewModel.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using DynamicData;
 using ReactiveUI;
 using WoWsShipBuilder.DataStructures;
+using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
 using WoWsShipBuilder.Features.DataContainers;
 using WoWsShipBuilder.Features.Navigation;
@@ -443,12 +444,12 @@ public partial class ShipComparisonViewModel : ReactiveObject
         }
         else if (obj is Ship ship)
         {
-            newWrapper = new(ShipBuildContainer.CreateNew(ship, null, null) with { ShipDataContainer = this.GetShipDataContainer(ship) });
+            newWrapper = new(ShipBuildContainer.CreateNew(ship, null, ImmutableArray<int>.Empty) with { ShipDataContainer = this.GetShipDataContainer(ship) });
         }
         else if (obj is string shipIndex)
         {
             var shipFromIndex = this.fullShipList.First(x => x.Index.Equals(shipIndex, StringComparison.Ordinal));
-            newWrapper = new(ShipBuildContainer.CreateNew(shipFromIndex, null, null) with { ShipDataContainer = this.GetShipDataContainer(shipFromIndex) });
+            newWrapper = new(ShipBuildContainer.CreateNew(shipFromIndex, null, ImmutableArray<int>.Empty) with { ShipDataContainer = this.GetShipDataContainer(shipFromIndex) });
         }
         else
         {
@@ -549,7 +550,7 @@ public partial class ShipComparisonViewModel : ReactiveObject
 
     private Dictionary<Guid, GridDataWrapper> InitialiseShipBuildContainers(IEnumerable<Ship> ships)
     {
-        return ships.Select(ship => new GridDataWrapper(ShipBuildContainer.CreateNew(ship, null, null) with { ShipDataContainer = this.GetShipDataContainer(ship) })).ToDictionary(x => x.Id, x => x);
+        return ships.Select(ship => new GridDataWrapper(ShipBuildContainer.CreateNew(ship, null, ImmutableArray<int>.Empty) with { ShipDataContainer = this.GetShipDataContainer(ship) })).ToDictionary(x => x.Id, x => x);
     }
 
     private void ChangeModulesBatch()
@@ -575,7 +576,7 @@ public partial class ShipComparisonViewModel : ReactiveObject
 
     private ShipDataContainer GetShipDataContainer(Ship ship)
     {
-        return ShipDataContainer.CreateFromShip(ship, this.GetShipConfiguration(ship), new());
+        return ShipDataContainer.CreateFromShip(ship, this.GetShipConfiguration(ship), ImmutableList<Modifier>.Empty);
     }
 
     private Dictionary<Guid, GridDataWrapper> HideShipsIfNoSelectedSection(IEnumerable<KeyValuePair<Guid, GridDataWrapper>> list)
@@ -701,7 +702,7 @@ public partial class ShipComparisonViewModel : ReactiveObject
 
     private GridDataWrapper ResetBuild(GridDataWrapper wrapper)
     {
-        GridDataWrapper reset = new(wrapper.ShipBuildContainer with { Build = null, ActivatedConsumableSlots = null, SpecialAbilityActive = false, ShipDataContainer = this.GetShipDataContainer(wrapper.Ship), Modifiers = null });
+        GridDataWrapper reset = new(wrapper.ShipBuildContainer with { Build = null, ActivatedConsumableSlots = ImmutableArray<int>.Empty, SpecialAbilityActive = false, ShipDataContainer = this.GetShipDataContainer(wrapper.Ship), Modifiers = ImmutableList<Modifier>.Empty });
         return reset;
     }
 

--- a/WoWsShipBuilder.Common/Features/ShipSelection/FittingToolSelector.razor
+++ b/WoWsShipBuilder.Common/Features/ShipSelection/FittingToolSelector.razor
@@ -136,7 +136,7 @@
 
     private void SelectShip(Ship ship)
     {
-        var shipBuildContainer = ShipBuildContainer.CreateNew(ship, null, null);
+        var shipBuildContainer = ShipBuildContainer.CreateNew(ship, null, ImmutableArray<int>.Empty);
 
         if (AppSettings.FittingToolSelectorMultiSelection)
         {

--- a/WoWsShipBuilder.Common/Features/ShipSelection/ShipSelector.razor
+++ b/WoWsShipBuilder.Common/Features/ShipSelection/ShipSelector.razor
@@ -409,12 +409,12 @@
         if (MultiSelect)
         {
             var ship = AppData.ShipDictionary[shipIndex];
-            SelectedShips.Add(ShipBuildContainer.CreateNew(ship, null, null));
+            SelectedShips.Add(ShipBuildContainer.CreateNew(ship, null, ImmutableArray<int>.Empty));
         }
         else if (!MultiSelect && SelectedShips.Count == 0)
         {
             var ship = AppData.ShipDictionary[shipIndex];
-            SelectedShips.Add(ShipBuildContainer.CreateNew(ship, null, null));
+            SelectedShips.Add(ShipBuildContainer.CreateNew(ship, null, ImmutableArray<int>.Empty));
         }
     }
 
@@ -425,12 +425,12 @@
         if (MultiSelect)
         {
             MetricsService.BuildImports.WithLabels("ship-selector", "saved-builds").Inc();
-            SelectedShips.Add(ShipBuildContainer.CreateNew(AppData.ShipDictionary[build.ShipIndex], build, null));
+            SelectedShips.Add(ShipBuildContainer.CreateNew(AppData.ShipDictionary[build.ShipIndex], build, ImmutableArray<int>.Empty));
         }
         else if (!MultiSelect && SelectedShips.Count == 0)
         {
             MetricsService.BuildImports.WithLabels("ship-selector", "saved-builds").Inc();
-            SelectedShips.Add(ShipBuildContainer.CreateNew(AppData.ShipDictionary[build.ShipIndex], build, null));
+            SelectedShips.Add(ShipBuildContainer.CreateNew(AppData.ShipDictionary[build.ShipIndex], build, ImmutableArray<int>.Empty));
         }
     }
 

--- a/WoWsShipBuilder.Common/Features/ShipStats/Components/ShipStatsPanel.razor
+++ b/WoWsShipBuilder.Common/Features/ShipStats/Components/ShipStatsPanel.razor
@@ -271,7 +271,7 @@
                 <MudItem xs="12" lg="4">
                     <MudExpansionPanels MultiExpansion Dense DisableGutters Class="my-n4">
                         <!--Secondaries-->
-                        @if (ViewModel.CurrentShipStats?.SecondaryBatteryUiDataContainer.Secondaries is not null)
+                        @if (ViewModel.CurrentShipStats is not null && !ViewModel.CurrentShipStats.SecondaryBatteryUiDataContainer.Secondaries.IsEmpty)
                         {
                             <MudExpansionPanel Text="@Localizer.GetAppLocalization(nameof(Translation.ShipStats_SecondaryBattery)).Localization" @bind-IsExpanded="@ExpanderStateCache["main-secondary"]" Style="border-bottom: initial" Class="custom-expansion-panel-header header-border border border-solid my-4">
                                 <MudStack Spacing="1" Class="expander-content-padding">

--- a/WoWsShipBuilder.Common/Features/ShipStats/Components/ShipStatsPanel.razor
+++ b/WoWsShipBuilder.Common/Features/ShipStats/Components/ShipStatsPanel.razor
@@ -157,7 +157,7 @@
                                                         @DataElementFragment((data, Localizer))
                                                     }
                                                 }
-                                                @if (torpedo.CanHitClasses is not null)
+                                                @if (!torpedo.CanHitClasses.IsEmpty)
                                                 {
                                                     <div class="d-flex justify-space-between">
                                                         <MudText Typo="Typo.body2" Class="flex-grow-0 flex-shrink-1">

--- a/WoWsShipBuilder.Common/Features/ShipStats/Components/ShipStatsTab.razor
+++ b/WoWsShipBuilder.Common/Features/ShipStats/Components/ShipStatsTab.razor
@@ -308,7 +308,7 @@ else if (ViewModel is not null)
                 var oldCacheEntry = Cache[CurrentTabId]!;
                 Cache[CurrentTabId] = oldCacheEntry with { ViewModel = ViewModel };
                 oldCacheEntry.ViewModel.Dispose();
-                await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToImmutableList(), new());
+                await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToImmutableList(), ImmutableList<Modifier>.Empty);
                 StateHasChanged();
             }
         }
@@ -364,10 +364,11 @@ else if (ViewModel is not null)
 
     public static ShipBuildContainer GetBuildContainer(Guid containerId, VmCacheEntry cacheEntry, bool calculateShipDataContainer)
     {
-        List<Modifier> modifiers = cacheEntry.ViewModel.UpgradePanelViewModel.GetModifierList();
-        modifiers.AddRange(cacheEntry.ViewModel.ConsumableViewModel.GetModifiersList());
-        modifiers.AddRange(cacheEntry.ViewModel.CaptainSkillSelectorViewModel?.GetModifiersList() ?? new List<Modifier>());
-        modifiers.AddRange(cacheEntry.ViewModel.SignalSelectorViewModel?.GetModifierList() ?? new List<Modifier>());
+        List<Modifier> modifierBuilder = cacheEntry.ViewModel.UpgradePanelViewModel.GetModifierList();
+        modifierBuilder.AddRange(cacheEntry.ViewModel.ConsumableViewModel.GetModifiersList());
+        modifierBuilder.AddRange(cacheEntry.ViewModel.CaptainSkillSelectorViewModel?.GetModifiersList() ?? new List<Modifier>());
+        modifierBuilder.AddRange(cacheEntry.ViewModel.SignalSelectorViewModel?.GetModifierList() ?? new List<Modifier>());
+        var modifiers = modifierBuilder.ToImmutableList();
 
         bool isCustomBuild = !string.IsNullOrWhiteSpace(cacheEntry.BuildName) || cacheEntry.ViewModel.ShipModuleViewModel.SelectedModules.Any(m => !string.IsNullOrEmpty(m.Prev)) ||
                              cacheEntry.ViewModel.UpgradePanelViewModel.SelectedModernizationList.Any() || cacheEntry.ViewModel.ConsumableViewModel.ActivatedSlots.Any() ||
@@ -375,7 +376,7 @@ else if (ViewModel is not null)
 
         var ship = AppData.FindShipFromSummary(cacheEntry.ViewModel.CurrentShip);
         var build = isCustomBuild ? cacheEntry.ViewModel.CreateBuild(cacheEntry.BuildName) : null;
-        ObservableCollection<int>? activeConsumables = cacheEntry.ViewModel.ConsumableViewModel.ActivatedSlots.Any() ? cacheEntry.ViewModel.ConsumableViewModel.ActivatedSlots : null;
+        var activeConsumables = cacheEntry.ViewModel.ConsumableViewModel.ActivatedSlots.Any() ? cacheEntry.ViewModel.ConsumableViewModel.ActivatedSlots.ToImmutableArray() : ImmutableArray<int>.Empty;
         ShipDataContainer? shipDataContainer = null;
         if (calculateShipDataContainer)
         {

--- a/WoWsShipBuilder.Common/Features/ShipStats/Components/ShipStatsTab.razor
+++ b/WoWsShipBuilder.Common/Features/ShipStats/Components/ShipStatsTab.razor
@@ -20,6 +20,7 @@
 @using WoWsShipBuilder.DataStructures.Modifiers
 @using WoWsShipBuilder.Features.Navigation
 @using WoWsShipBuilder.Infrastructure.DataTransfer
+@using System.Collections.Immutable
 
 @inject IHostEnvironment Environment
 @inject ILocalizer Localizer
@@ -307,7 +308,7 @@ else if (ViewModel is not null)
                 var oldCacheEntry = Cache[CurrentTabId]!;
                 Cache[CurrentTabId] = oldCacheEntry with { ViewModel = ViewModel };
                 oldCacheEntry.ViewModel.Dispose();
-                await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToList(), new());
+                await ViewModel.ShipStatsControlViewModel!.UpdateShipStats(ViewModel.ShipModuleViewModel.SelectedModules.ToImmutableList(), new());
                 StateHasChanged();
             }
         }

--- a/WoWsShipBuilder.Common/Features/ShipStats/DepthChargeDamageDistributionChartRecord.cs
+++ b/WoWsShipBuilder.Common/Features/ShipStats/DepthChargeDamageDistributionChartRecord.cs
@@ -1,3 +1,5 @@
-﻿namespace WoWsShipBuilder.Features.ShipStats;
+﻿using System.Collections.Immutable;
 
-public sealed record DepthChargeDamageDistributionChartRecord(int DcDmg, decimal SplashRadius, Dictionary<float, List<float>> PointsOfDmg = default!);
+namespace WoWsShipBuilder.Features.ShipStats;
+
+public sealed record DepthChargeDamageDistributionChartRecord(int DcDmg, decimal SplashRadius, ImmutableDictionary<float, ImmutableList<float>> PointsOfDmg);

--- a/WoWsShipBuilder.Common/Features/ShipStats/ShipStats.razor
+++ b/WoWsShipBuilder.Common/Features/ShipStats/ShipStats.razor
@@ -151,7 +151,7 @@
                     Logger.LogTrace("Build could not be loaded from url because it was not in the correct format");
                 }
 
-                buildList = new() { ShipBuildContainer.CreateNew(AppData.ShipDictionary[shipIndexesFromUrl], build, null) };
+                buildList = new() { ShipBuildContainer.CreateNew(AppData.ShipDictionary[shipIndexesFromUrl], build, ImmutableArray<int>.Empty) };
             }
             else if (buildContainers is not null)
             {
@@ -174,7 +174,7 @@
         if (oldId is not null)
         {
             var ship = shipContainers.First(x => x.Id.Equals(oldId));
-            shipContainers.Replace(ship, ship with { Ship = AppData.ShipDictionary[newShipIndex], Build = null, ShipDataContainer = null, SpecialAbilityActive = false, ActivatedConsumableSlots = null, Modifiers = null });
+            shipContainers.Replace(ship, ship with { Ship = AppData.ShipDictionary[newShipIndex], Build = null, ShipDataContainer = null, SpecialAbilityActive = false, ActivatedConsumableSlots = ImmutableArray<int>.Empty, Modifiers = ImmutableList<Modifier>.Empty });
             selectedTabId = (Guid) oldId;
             update = true;
         }
@@ -245,7 +245,7 @@
 
     private void AddNewIndexes(IEnumerable<string> indexList, IEnumerable<ShipBuildContainer>? buildContainers)
     {
-        shipContainers.AddRange(buildContainers ?? indexList.Select(index => ShipBuildContainer.CreateNew(AppData.ShipDictionary[index], null, null)));
+        shipContainers.AddRange(buildContainers ?? indexList.Select(index => ShipBuildContainer.CreateNew(AppData.ShipDictionary[index], null, ImmutableArray<int>.Empty)));
     }
 
     private ImmutableList<ShipBuildContainer> GetShipBuildContainers(bool calculateShipDataContainer)
@@ -273,10 +273,11 @@
         {
             using var viewModel = ShipStatsTab.CreateViewModel(container.Ship.Index, container.Build);
 
-            List<Modifier> modifiers = viewModel.UpgradePanelViewModel.GetModifierList();
-            modifiers.AddRange(viewModel.ConsumableViewModel.GetModifiersList());
-            modifiers.AddRange(viewModel.CaptainSkillSelectorViewModel?.GetModifiersList() ?? new List<Modifier>());
-            modifiers.AddRange(viewModel.SignalSelectorViewModel?.GetModifierList() ?? new List<Modifier>());
+            List<Modifier> modifierBuilder = viewModel.UpgradePanelViewModel.GetModifierList();
+            modifierBuilder.AddRange(viewModel.ConsumableViewModel.GetModifiersList());
+            modifierBuilder.AddRange(viewModel.CaptainSkillSelectorViewModel?.GetModifiersList() ?? new List<Modifier>());
+            modifierBuilder.AddRange(viewModel.SignalSelectorViewModel?.GetModifierList() ?? new List<Modifier>());
+            var modifiers = modifierBuilder.ToImmutableList();
 
             var newDataContainer = calculateShipDataContainer ? DataContainerUtility.GetShipDataContainerFromBuild(container.Ship, container.Build.Modules, container.Ship.ShipUpgradeInfo.ShipUpgrades, modifiers) : container.ShipDataContainer;
             return container with { Modifiers = modifiers, ShipDataContainer = newDataContainer };

--- a/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ConsumableSlotViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ConsumableSlotViewModel.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
+﻿using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using ReactiveUI;
 using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.DataStructures.Modifiers;
@@ -19,11 +19,6 @@ public class ConsumableSlotViewModel : ReactiveObject
     private List<ConsumableDataContainer> consumableData = new();
 
     private int selectedIndex;
-
-    public ConsumableSlotViewModel()
-        : this(new List<ShipConsumable>(), null, NullLogger<ConsumableSlotViewModel>.Instance)
-    {
-    }
 
     private ConsumableSlotViewModel(IEnumerable<ShipConsumable> shipConsumables, Action<int, bool>? activationChangeHandler, ILogger<ConsumableSlotViewModel> logger)
     {
@@ -72,11 +67,11 @@ public class ConsumableSlotViewModel : ReactiveObject
     public static ConsumableSlotViewModel Create(IEnumerable<ShipConsumable> shipConsumables, ILoggerFactory loggerFactory, ShipClass shipClass, Action<int, bool>? activationChangeHandler = null)
     {
         var vm = new ConsumableSlotViewModel(shipConsumables, activationChangeHandler, loggerFactory.CreateLogger<ConsumableSlotViewModel>());
-        vm.UpdateDataContainers(new(), 0, shipClass);
+        vm.UpdateDataContainers(ImmutableList<Modifier>.Empty, 0, shipClass);
         return vm;
     }
 
-    public void UpdateDataContainers(List<Modifier> modifiers, int shipHp, ShipClass shipClass)
+    public void UpdateDataContainers(ImmutableList<Modifier> modifiers, int shipHp, ShipClass shipClass)
     {
         var dataContainers = this.shipConsumables.Select(c => ConsumableDataContainer.FromTypeAndVariant(c, modifiers, false, shipHp, shipClass));
         this.ConsumableData = dataContainers.ToList();

--- a/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ConsumableViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ConsumableViewModel.cs
@@ -81,7 +81,7 @@ public class ConsumableViewModel : ReactiveObject, IBuildComponentProvider
     /// <param name="modifiers">The list of modifiers applied to the current ship.</param>
     /// <param name="shipHp">The HP of the ship after modifiers have been applied.</param>
     /// <param name="shipClass">The class of the ship.</param>
-    public void UpdateConsumableData(List<Modifier> modifiers, int shipHp, ShipClass shipClass)
+    public void UpdateConsumableData(ImmutableList<Modifier> modifiers, int shipHp, ShipClass shipClass)
     {
         Parallel.ForEach(this.ConsumableSlots, consumableSlot => consumableSlot.UpdateDataContainers(modifiers, shipHp, shipClass));
     }

--- a/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ShipStatsControlViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ShipStatsControlViewModel.cs
@@ -32,7 +32,7 @@ public partial class ShipStatsControlViewModel : ReactiveObject
     // this is the ship base stats. do not modify after creation
     private Ship BaseShipStats { get; set; }
 
-    public async Task UpdateShipStats(ImmutableList<ShipUpgrade> selectedConfiguration, List<Modifier> modifiers)
+    public async Task UpdateShipStats(ImmutableList<ShipUpgrade> selectedConfiguration, ImmutableList<Modifier> modifiers)
     {
         var shipStats = await Task.Run(() => ShipDataContainer.CreateFromShip(this.BaseShipStats, selectedConfiguration, modifiers));
         this.CurrentShipStats = shipStats;

--- a/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ShipStatsControlViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ShipStatsControlViewModel.cs
@@ -1,8 +1,8 @@
+using System.Collections.Immutable;
 using ReactiveUI;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
 using WoWsShipBuilder.Features.DataContainers;
-using WoWsShipBuilder.Infrastructure.Utility;
 
 namespace WoWsShipBuilder.Features.ShipStats.ViewModels;
 
@@ -32,9 +32,9 @@ public partial class ShipStatsControlViewModel : ReactiveObject
     // this is the ship base stats. do not modify after creation
     private Ship BaseShipStats { get; set; }
 
-    public async Task UpdateShipStats(List<ShipUpgrade> selectedConfiguration, List<Modifier> modifiers)
+    public async Task UpdateShipStats(ImmutableList<ShipUpgrade> selectedConfiguration, List<Modifier> modifiers)
     {
-        ShipDataContainer shipStats = await Task.Run(() => ShipDataContainer.CreateFromShip(this.BaseShipStats, selectedConfiguration, modifiers));
+        var shipStats = await Task.Run(() => ShipDataContainer.CreateFromShip(this.BaseShipStats, selectedConfiguration, modifiers));
         this.CurrentShipStats = shipStats;
     }
 

--- a/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ShipViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ShipViewModel.cs
@@ -175,7 +175,7 @@ public sealed partial class ShipViewModel : ReactiveObject, IDisposable
                         await this.semaphore.WaitAsync(token);
                         try
                         {
-                            List<Modifier> modifiers = this.GenerateModifierList();
+                            ImmutableList<Modifier> modifiers = this.GenerateModifierList();
                             if (this.ShipStatsControlViewModel != null)
                             {
                                 this.logger.LogDebug("Updating ship stats");
@@ -198,7 +198,7 @@ public sealed partial class ShipViewModel : ReactiveObject, IDisposable
             token);
     }
 
-    private List<Modifier> GenerateModifierList()
+    private ImmutableList<Modifier> GenerateModifierList()
     {
         var modifiers = new List<Modifier>();
 
@@ -207,7 +207,7 @@ public sealed partial class ShipViewModel : ReactiveObject, IDisposable
         modifiers.AddRange(this.CaptainSkillSelectorViewModel!.GetModifiersList());
         modifiers.AddRange(this.ConsumableViewModel.GetModifiersList());
         modifiers.AddRange(this.ShipStatsControlViewModel!.GetSpecialAbilityModifiers());
-        return modifiers;
+        return modifiers.ToImmutableList();
     }
 
     public void Dispose()

--- a/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ShipViewModel.cs
+++ b/WoWsShipBuilder.Common/Features/ShipStats/ViewModels/ShipViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData.Binding;
@@ -178,7 +179,7 @@ public sealed partial class ShipViewModel : ReactiveObject, IDisposable
                             if (this.ShipStatsControlViewModel != null)
                             {
                                 this.logger.LogDebug("Updating ship stats");
-                                await this.ShipStatsControlViewModel.UpdateShipStats(this.ShipModuleViewModel.SelectedModules.ToList(), modifiers);
+                                await this.ShipStatsControlViewModel.UpdateShipStats(this.ShipModuleViewModel.SelectedModules.ToImmutableList(), modifiers);
                             }
 
                             this.ConsumableViewModel.UpdateConsumableData(modifiers, this.ShipStatsControlViewModel!.CurrentShipStats!.SurvivabilityDataContainer.HitPoints, this.RawShipData.ShipClass);

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/DataElementAnalyzerTest.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/DataElementAnalyzerTest.cs
@@ -1,15 +1,12 @@
 ﻿using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.CSharp.Testing.NUnit;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using WoWsShipBuilder.Data.Generator.DataElementGenerator;
 using WoWsShipBuilder.DataElements;
 
 namespace WoWsShipBuilder.Data.Generator.Test.DataElementAnalyzerTests;
-
-using Verify = AnalyzerVerifier<DataElementAnalyzer>;
 
 [TestFixture]
 public partial class DataElementAnalyzerTest
@@ -24,7 +21,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType((DataElementTypes)128)]
                          public decimal {|SB0001:Prop1|} { get; set; }
@@ -40,7 +37,7 @@ public partial class DataElementAnalyzerTest
         const string baseClass = """
                                  namespace WoWsShipBuilder.DataElements;
 
-                                 public abstract record DataContainerBase
+                                 public abstract class DataContainerBase
                                  {
                                      public global::System.Collections.Generic.List<IDataElement> DataElements { get; } = new();
 

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/FormattedText.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/FormattedText.cs
@@ -12,7 +12,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName="Test")]
                          public decimal Prop1 { get; set; }
@@ -32,7 +32,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText)]
                          public decimal {|SB1002:Prop1|} { get; set; }
@@ -52,7 +52,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = "Test", ArgumentsTextKind = TextKind.LocalizationKey)]
                          public decimal Prop1 { get; set; }
@@ -72,7 +72,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = "Test", ArgumentsTextKind = TextKind.AppLocalizationKey)]
                          public decimal Prop1 { get; set; }
@@ -92,7 +92,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = "Test", LocalizationKeyOverride = "Test")]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -112,7 +112,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = "Test", UnitKey = "Test")]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -132,7 +132,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = "Test", TooltipKey = "Test")]
                          public decimal {|SB1003:Prop1|} { get; set; }

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/Grouped.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/Grouped.cs
@@ -12,7 +12,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord: DataContainerBase
+                     public partial class TestDataContainer: DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue, GroupKey = "Loaders")]
                          public string Prop1 { get; set; } = default!;
@@ -32,7 +32,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord: DataContainerBase
+                     public partial class TestDataContainer: DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Grouped, GroupKey = "Loaders")]
                          public string {|SB0002:Prop1|} { get; set; } = default!;
@@ -52,7 +52,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord: DataContainerBase
+                     public partial class TestDataContainer: DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue)]
                          public string {|SB1001:Prop1|} { get; set; } = default!;
@@ -72,7 +72,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord: DataContainerBase
+                     public partial class TestDataContainer: DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue, GroupKey="Test")]
                          public string {|SB1003:Prop1|} { get; set; } = default!;

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/KeyValue.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/KeyValue.cs
@@ -12,7 +12,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue)]
                          public decimal Prop1 { get; set; }
@@ -32,7 +32,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue, LocalizationKeyOverride = "Test")]
                          public decimal Prop1 { get; set; }
@@ -52,7 +52,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue, ArgumentsCollectionName = "Values")]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -72,7 +72,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue, ArgumentsTextKind = TextKind.LocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -92,7 +92,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue, ArgumentsTextKind = TextKind.AppLocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -112,7 +112,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue, UnitKey="Test")]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -132,7 +132,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue, TooltipKey="Test")]
                          public decimal {|SB1003:Prop1|} { get; set; }

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/KeyValueUnit.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/KeyValueUnit.cs
@@ -12,7 +12,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "Test")]
                          public decimal Prop1 { get; set; }
@@ -32,7 +32,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "Test", LocalizationKeyOverride = "Test")]
                          public decimal Prop1 { get; set; }
@@ -52,7 +52,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit)]
                          public decimal {|SB1002:Prop1|} { get; set; }
@@ -72,7 +72,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "Test", ArgumentsCollectionName = "Values")]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -92,7 +92,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "Test", ArgumentsTextKind = TextKind.LocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -112,7 +112,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "Test", ArgumentsTextKind = TextKind.AppLocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -132,7 +132,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "Test", TooltipKey = "Test")]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -152,7 +152,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "Test", ValueTextKind = TextKind.LocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -172,7 +172,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "Test", ValueTextKind = TextKind.AppLocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/Tooltip.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/Tooltip.cs
@@ -12,7 +12,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip, TooltipKey = "Test")]
                          public decimal Prop1 { get; set; }
@@ -32,7 +32,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip)]
                          public decimal {|SB1002:Prop1|} { get; set; }
@@ -52,7 +52,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip, TooltipKey = "Test", UnitKey = "Test")]
                          public decimal Prop1 { get; set; }
@@ -72,7 +72,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip, TooltipKey = "Test", LocalizationKeyOverride = "Test")]
                          public decimal Prop1 { get; set; }
@@ -92,7 +92,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip, TooltipKey = "Test", ArgumentsCollectionName = "Values")]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -112,7 +112,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip, TooltipKey = "Test", ArgumentsTextKind = TextKind.LocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -132,7 +132,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip, TooltipKey = "Test", ArgumentsTextKind = TextKind.AppLocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -152,7 +152,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip, TooltipKey = "Test", ValueTextKind = TextKind.LocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -172,7 +172,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip, TooltipKey = "Test", ValueTextKind = TextKind.AppLocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/Value.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementAnalyzerTests/Value.cs
@@ -12,7 +12,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Value)]
                          public decimal Prop1 { get; set; }
@@ -32,7 +32,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Value, ArgumentsCollectionName = "Values")]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -52,7 +52,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Value, ArgumentsTextKind = TextKind.LocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -72,7 +72,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Value, ArgumentsTextKind = TextKind.AppLocalizationKey)]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -92,7 +92,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Value, UnitKey = "Test")]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -112,7 +112,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Value, TooltipKey = "Test")]
                          public decimal {|SB1003:Prop1|} { get; set; }
@@ -132,7 +132,7 @@ public partial class DataElementAnalyzerTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Value, LocalizationKeyOverride = "Test")]
                          public decimal {|SB1003:Prop1|} { get; set; }

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/DataElementGeneratorTest.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/DataElementGeneratorTest.cs
@@ -19,7 +19,7 @@ public partial class DataElementGeneratorTest
         const string baseClass = """
                                  namespace WoWsShipBuilder.DataElements;
 
-                                 public abstract record DataContainerBase
+                                 public abstract class DataContainerBase
                                  {
                                      public global::System.Collections.Generic.List<IDataElement> DataElements { get; } = new();
 
@@ -48,7 +48,7 @@ public partial class DataElementGeneratorTest
                     (typeof(DataElementGenerator.DataElementGenerator), "DataContainerAttribute.g.cs", AttributeHelper.DataContainerAttribute),
                     (typeof(DataElementGenerator.DataElementGenerator), "DataElementTypeAttribute.g.cs", AttributeHelper.DataElementTypeAttribute),
                     (typeof(DataElementGenerator.DataElementGenerator), "DataElementFilteringAttribute.g.cs", AttributeHelper.DataElementFilteringAttribute),
-                    (typeof(DataElementGenerator.DataElementGenerator), "TestRecord.g.cs", expected),
+                    (typeof(DataElementGenerator.DataElementGenerator), "TestDataContainer.g.cs", expected),
                 },
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
                 AdditionalReferences = { MetadataReference.CreateFromFile(typeof(IDataElement).GetTypeInfo().Assembly.Location) },

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/FormattedText.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/FormattedText.cs
@@ -15,7 +15,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = nameof(TestValues))]
                          public string Test { get; set; } = default!;
@@ -29,7 +29,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -60,7 +60,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = nameof(TestValues), ArgumentsTextKind = TextKind.LocalizationKey)]
                          public string Test { get; set; } = default!;
@@ -74,7 +74,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -105,7 +105,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = nameof(TestValues), ValueTextKind = TextKind.LocalizationKey)]
                          public string Test { get; set; } = default!;
@@ -119,7 +119,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -150,7 +150,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = nameof(TestValues), ValueTextKind = TextKind.LocalizationKey, ArgumentsTextKind = TextKind.LocalizationKey)]
                          public string Test { get; set; } = default!;
@@ -164,7 +164,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -195,7 +195,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = nameof(TestValues), ArgumentsTextKind = TextKind.AppLocalizationKey)]
                          public string Test { get; set; } = default!;
@@ -209,7 +209,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -240,7 +240,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = nameof(TestValues), ValueTextKind = TextKind.AppLocalizationKey)]
                          public string Test { get; set; } = default!;
@@ -254,7 +254,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -285,7 +285,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.FormattedText, ArgumentsCollectionName = nameof(TestValues), ValueTextKind = TextKind.AppLocalizationKey, ArgumentsTextKind = TextKind.AppLocalizationKey)]
                          public string Test { get; set; } = default!;
@@ -299,7 +299,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/Grouped.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/Grouped.cs
@@ -13,7 +13,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue, GroupKey = "Loaders")]
                          public string BowLoaders { get; set; } = default!;
@@ -28,7 +28,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -68,7 +68,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValue, GroupKey = "Group1")]
                          public string Prop1 { get; set; } = default!;
@@ -89,7 +89,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/KeyValue.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/KeyValue.cs
@@ -13,7 +13,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue)]
                          public decimal Prop1 { get; set; }
@@ -25,7 +25,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -54,7 +54,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue, ValueTextKind = TextKind.LocalizationKey)]
                          public decimal Prop1 { get; set; }
@@ -66,7 +66,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -95,7 +95,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue, ValueTextKind = TextKind.AppLocalizationKey)]
                          public decimal Prop1 { get; set; }
@@ -107,7 +107,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/KeyValueUnit.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/KeyValueUnit.cs
@@ -13,7 +13,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "Knots")]
                          public decimal Prop1 { get; set; }
@@ -25,7 +25,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/Mixed.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/Mixed.cs
@@ -12,7 +12,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                      }
                      """;
@@ -22,7 +22,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -46,7 +46,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "FPM")]
                          [DataElementFiltering(true, nameof(this.ShouldDisplayTest))]
@@ -64,7 +64,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -94,7 +94,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.KeyValue, ValueTextKind = TextKind.LocalizationKey)]
                          public string Prop1 { get; set; } = default!;
@@ -117,7 +117,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/Tooltip.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/Tooltip.cs
@@ -13,7 +13,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip, TooltipKey = "TestTooltip")]
                          public decimal Prop1 { get; set; }
@@ -25,7 +25,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -54,7 +54,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Tooltip, TooltipKey = "TestTooltip", UnitKey="Knots")]
                          public decimal Prop1 { get; set; }
@@ -66,7 +66,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {

--- a/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/Value.cs
+++ b/WoWsShipBuilder.Data.Generator.Test/DataElementGeneratorTests/Value.cs
@@ -13,7 +13,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Value)]
                          public decimal Prop1 { get; set; }
@@ -25,7 +25,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -54,7 +54,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Value, ValueTextKind = TextKind.LocalizationKey)]
                          public decimal Prop1 { get; set; }
@@ -66,7 +66,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {
@@ -95,7 +95,7 @@ public partial class DataElementGeneratorTest
                      namespace Test;
 
                      [DataContainer]
-                     public partial record TestRecord : DataContainerBase
+                     public partial class TestDataContainer : DataContainerBase
                      {
                          [DataElementType(DataElementTypes.Value, ValueTextKind = TextKind.AppLocalizationKey)]
                          public decimal Prop1 { get; set; }
@@ -107,7 +107,7 @@ public partial class DataElementGeneratorTest
                        #nullable enable
                        namespace Test
                        {
-                           public partial record TestRecord
+                           public partial class TestDataContainer
                            {
                                private void UpdateDataElements()
                                {

--- a/WoWsShipBuilder.DataElements/DataContainerBase.cs
+++ b/WoWsShipBuilder.DataElements/DataContainerBase.cs
@@ -2,7 +2,7 @@
 
 namespace WoWsShipBuilder.DataElements;
 
-public abstract record DataContainerBase
+public abstract class DataContainerBase
 {
     public List<IDataElement> DataElements { get; } = new();
 

--- a/WoWsShipBuilder.Web/Features/TestPage/TestPage.razor
+++ b/WoWsShipBuilder.Web/Features/TestPage/TestPage.razor
@@ -11,6 +11,7 @@
 @using WoWsShipBuilder.Infrastructure.Utility
 @using MainBatteryDataContainer = WoWsShipBuilder.Features.DataContainers.MainBatteryDataContainer
 @using System.Collections.Immutable
+@using WoWsShipBuilder.DataStructures.Modifiers
 @inject ISettingsAccessor SettingsAccessor
 @inject AppSettings AppSettings
 @inject ILocalizer Localizer
@@ -75,11 +76,11 @@
     private void OpenFiringAngles()
     {
         var (ship, config) = LoadPreviewShip(ShipClass.Destroyer, 5, Nation.UnitedKingdom);
-        var data = MainBatteryDataContainer.FromShip(ship, config, new());
+        var data = MainBatteryDataContainer.FromShip(ship, config, ImmutableList<Modifier>.Empty);
         var records = data!.OriginalMainBatteryData.Guns.Select(gun =>
         {
             var sector = gun.HorizontalSector.Select(a => a + gun.BaseAngle).ToArray();
-            var deadZones = gun.HorizontalDeadZones.Select(z => z.Select(a => a + gun.BaseAngle).ToArray()).ToArray() ?? Array.Empty<decimal[]>();
+            var deadZones = gun.HorizontalDeadZones.Select(z => z.Select(a => a + gun.BaseAngle).ToArray()).ToArray();
             return new GunDataContainer(gun.HorizontalPosition, gun.VerticalPosition, gun.BaseAngle, sector, deadZones);
         });
 

--- a/WoWsShipBuilder.Web/Features/TestPage/TestPage.razor
+++ b/WoWsShipBuilder.Web/Features/TestPage/TestPage.razor
@@ -10,6 +10,7 @@
 @using WoWsShipBuilder.Infrastructure.Localization.Resources
 @using WoWsShipBuilder.Infrastructure.Utility
 @using MainBatteryDataContainer = WoWsShipBuilder.Features.DataContainers.MainBatteryDataContainer
+@using System.Collections.Immutable
 @inject ISettingsAccessor SettingsAccessor
 @inject AppSettings AppSettings
 @inject ILocalizer Localizer
@@ -58,7 +59,7 @@
         return (ship, configuration);
     }
 
-    private (Ship Ship, List<ShipUpgrade> Configuration) LoadPreviewShip(ShipClass shipClass, int tier, Nation nation)
+    private (Ship Ship, ImmutableList<ShipUpgrade> Configuration) LoadPreviewShip(ShipClass shipClass, int tier, Nation nation)
     {
         var ship = AppData.FindShipFromSummary(AppData.ShipSummaryMapper.Values.First(s => s.ShipClass == shipClass && s.Nation == nation && s.Tier == tier));
 
@@ -66,7 +67,7 @@
             .Select(entry => entry.Value.FirstOrDefault())
             .Where(item => item != null)
             .Cast<ShipUpgrade>()
-            .ToList();
+            .ToImmutableList();
 
         return (ship, configuration);
     }

--- a/WoWsShipBuilder.Web/Features/TestPage/TestPage2.razor
+++ b/WoWsShipBuilder.Web/Features/TestPage/TestPage2.razor
@@ -3,6 +3,7 @@
 @using WoWsShipBuilder.Features.Builds.Components
 @using WoWsShipBuilder.Features.Navigation
 @using WoWsShipBuilder.Infrastructure.ApplicationData
+@using System.Collections.Immutable
 
 <MudRadioGroup @bind-SelectedOption="selectedTier">
     @for (var i = 1; i <= 11; i++)
@@ -59,7 +60,7 @@
             .Where(s => s.Tier == selectedTier && s.ShipClass == selectedClass)
             .Take(25)
             .Select(AppData.FindShipFromSummary);
-        ships = shipList.Select(s => ShipBuildContainer.CreateNew(s, null, null)).ToList();
+        ships = shipList.Select(s => ShipBuildContainer.CreateNew(s, null, ImmutableArray<int>.Empty)).ToList();
         StateHasChanged();
     }
 


### PR DESCRIPTION
- data containers now receive immutable parameters
- data containers are now implemented as classes instead of records due to them not making use of any record features
- consumable property selector names have been updated to follow the common naming pattern
- default modifiers (cooldown, worktime, uses) are now automatically applied for all consumables