### PR TITLE
Burst Mode Enhancement

### DIFF
--- a/src/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
+++ b/src/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
@@ -35,9 +35,11 @@ public partial class MainBatteryDataContainer : DataContainerBase
     public decimal Reload { get; set; }
 
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "BurstMode", UnitKey = "S")]
+    [DataElementFiltering(true, "ShouldDisplayBurstReload")]
     public decimal BurstDuringReload { get; set; }
 
     [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "BurstMode", UnitKey = "S")]
+    [DataElementFiltering(true, "ShouldDisplayBurstReload")]
     public decimal BurstAfterReload { get; set; }
 
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "ShotsPerMinute")]
@@ -218,7 +220,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
             TurretNames = turretNames.ToImmutableList(),
             Range = Math.Round(range, 2),
             AmmoSwitchTime = Math.Round(ammoSwitchTime, 2),
-            RoF = Math.Round(rateOfFire * barrelCount * numberOfShots, 1),
+            RoF = Math.Round(rateOfFire * barrelCount, 1),
             TurnTime = Math.Round(180 / traverseSpeed, 1),
             TraverseSpeed = Math.Round(traverseSpeed, 2),
             Sigma = mainBattery.Sigma,
@@ -246,22 +248,22 @@ public partial class MainBatteryDataContainer : DataContainerBase
         if (mainBatteryDataContainer.DisplayHeDpm)
         {
             var heShell = shellData.First(x => x.Type.Equals($"ArmamentType_{ShellType.HE.ShellTypeToString()}", StringComparison.Ordinal));
-            mainBatteryDataContainer.TheoreticalHeDpm = Math.Round(heShell.Damage * barrelCount * numberOfShots * rateOfFire).ToString("n0", nfi);
+            mainBatteryDataContainer.TheoreticalHeDpm = Math.Round(heShell.Damage * barrelCount * rateOfFire).ToString("n0", nfi);
             mainBatteryDataContainer.HeSalvo = Math.Round(heShell.Damage * barrelCount * numberOfShots).ToString("n0", nfi);
-            mainBatteryDataContainer.PotentialFpm = Math.Round(heShell.ShellFireChance / 100 * barrelCount * numberOfShots * rateOfFire, 2);
+            mainBatteryDataContainer.PotentialFpm = Math.Round(heShell.ShellFireChance / 100 * barrelCount * rateOfFire, 2);
         }
 
         if (mainBatteryDataContainer.DisplayApDpm)
         {
             decimal shellDamage = shellData.First(x => x.Type.Equals($"ArmamentType_{ShellType.AP.ShellTypeToString()}", StringComparison.Ordinal)).Damage;
-            mainBatteryDataContainer.TheoreticalApDpm = Math.Round(shellDamage * barrelCount * numberOfShots * rateOfFire).ToString("n0", nfi);
+            mainBatteryDataContainer.TheoreticalApDpm = Math.Round(shellDamage * barrelCount * rateOfFire).ToString("n0", nfi);
             mainBatteryDataContainer.ApSalvo = Math.Round(shellDamage * barrelCount * numberOfShots).ToString("n0", nfi);
         }
 
         if (mainBatteryDataContainer.DisplaySapDpm)
         {
             decimal shellDamage = shellData.First(x => x.Type.Equals($"ArmamentType_{ShellType.SAP.ShellTypeToString()}", StringComparison.Ordinal)).Damage;
-            mainBatteryDataContainer.TheoreticalSapDpm = Math.Round(shellDamage * barrelCount * numberOfShots * rateOfFire).ToString("n0", nfi);
+            mainBatteryDataContainer.TheoreticalSapDpm = Math.Round(shellDamage * barrelCount * rateOfFire).ToString("n0", nfi);
             mainBatteryDataContainer.SapSalvo = Math.Round(shellDamage * barrelCount * numberOfShots).ToString("n0", nfi);
         }
 

--- a/src/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
+++ b/src/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
@@ -164,10 +164,11 @@ public partial class MainBatteryDataContainer : DataContainerBase
 
         // Calculate main battery reload
         decimal reload = gun.Reload;
+        var numberOfShots = 1;
         if (isBurstMode)
         {
             reload = burstModeAbility.ReloadAfterBurst;
-            barrelCount *= burstModeAbility.ShotInBurst;
+            numberOfShots = burstModeAbility.ShotInBurst;
         }
 
         reload = modifiers.ApplyModifiers("MainBatteryDataContainer.Reload", reload);
@@ -206,7 +207,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
         // Get burst mode ammo list
         var burstModeAmmoList = burstModeAbility?.AlternateShells;
         var ammoList = (burstModeAmmoList?.Length > 0 && isBurstMode) ? burstModeAmmoList : gun.AmmoList;
-        var shellData = ShellDataContainer.FromShellName(ammoList, modifiers, barrelCount, true);
+        var shellData = ShellDataContainer.FromShellName(ammoList, modifiers, barrelCount, numberOfShots, true);
 
         var (horizontalDispersion, verticalDispersion) = dispersion.CalculateDispersion((double)range * 1000, dispersionModifier);
 
@@ -217,7 +218,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
             TurretNames = turretNames.ToImmutableList(),
             Range = Math.Round(range, 2),
             AmmoSwitchTime = Math.Round(ammoSwitchTime, 2),
-            RoF = Math.Round(rateOfFire * barrelCount, 1),
+            RoF = Math.Round(rateOfFire * barrelCount * numberOfShots, 1),
             TurnTime = Math.Round(180 / traverseSpeed, 1),
             TraverseSpeed = Math.Round(traverseSpeed, 2),
             Sigma = mainBattery.Sigma,
@@ -245,23 +246,23 @@ public partial class MainBatteryDataContainer : DataContainerBase
         if (mainBatteryDataContainer.DisplayHeDpm)
         {
             var heShell = shellData.First(x => x.Type.Equals($"ArmamentType_{ShellType.HE.ShellTypeToString()}", StringComparison.Ordinal));
-            mainBatteryDataContainer.TheoreticalHeDpm = Math.Round(heShell.Damage * barrelCount * rateOfFire).ToString("n0", nfi);
-            mainBatteryDataContainer.HeSalvo = Math.Round(heShell.Damage * barrelCount).ToString("n0", nfi);
-            mainBatteryDataContainer.PotentialFpm = Math.Round(heShell.ShellFireChance / 100 * barrelCount * rateOfFire, 2);
+            mainBatteryDataContainer.TheoreticalHeDpm = Math.Round(heShell.Damage * barrelCount * numberOfShots * rateOfFire).ToString("n0", nfi);
+            mainBatteryDataContainer.HeSalvo = Math.Round(heShell.Damage * barrelCount * numberOfShots).ToString("n0", nfi);
+            mainBatteryDataContainer.PotentialFpm = Math.Round(heShell.ShellFireChance / 100 * barrelCount * numberOfShots * rateOfFire, 2);
         }
 
         if (mainBatteryDataContainer.DisplayApDpm)
         {
             decimal shellDamage = shellData.First(x => x.Type.Equals($"ArmamentType_{ShellType.AP.ShellTypeToString()}", StringComparison.Ordinal)).Damage;
-            mainBatteryDataContainer.TheoreticalApDpm = Math.Round(shellDamage * barrelCount * rateOfFire).ToString("n0", nfi);
-            mainBatteryDataContainer.ApSalvo = Math.Round(shellDamage * barrelCount).ToString("n0", nfi);
+            mainBatteryDataContainer.TheoreticalApDpm = Math.Round(shellDamage * barrelCount * numberOfShots * rateOfFire).ToString("n0", nfi);
+            mainBatteryDataContainer.ApSalvo = Math.Round(shellDamage * barrelCount * numberOfShots).ToString("n0", nfi);
         }
 
         if (mainBatteryDataContainer.DisplaySapDpm)
         {
             decimal shellDamage = shellData.First(x => x.Type.Equals($"ArmamentType_{ShellType.SAP.ShellTypeToString()}", StringComparison.Ordinal)).Damage;
-            mainBatteryDataContainer.TheoreticalSapDpm = Math.Round(shellDamage * barrelCount * rateOfFire).ToString("n0", nfi);
-            mainBatteryDataContainer.SapSalvo = Math.Round(shellDamage * barrelCount).ToString("n0", nfi);
+            mainBatteryDataContainer.TheoreticalSapDpm = Math.Round(shellDamage * barrelCount * numberOfShots * rateOfFire).ToString("n0", nfi);
+            mainBatteryDataContainer.SapSalvo = Math.Round(shellDamage * barrelCount * numberOfShots).ToString("n0", nfi);
         }
 
         if (mainBatteryDataContainer.DisplayBurstReload)

--- a/src/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
+++ b/src/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Text;
 using WoWsShipBuilder.DataElements;
@@ -33,6 +33,12 @@ public partial class MainBatteryDataContainer : DataContainerBase
 
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "S")]
     public decimal Reload { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "BurstMode", UnitKey = "S")]
+    public decimal BurstDuringReload { get; set; }
+
+    [DataElementType(DataElementTypes.Grouped | DataElementTypes.KeyValueUnit, GroupKey = "BurstMode", UnitKey = "S")]
+    public decimal BurstAfterReload { get; set; }
 
     [DataElementType(DataElementTypes.KeyValueUnit, UnitKey = "ShotsPerMinute")]
     public decimal RoF { get; set; }
@@ -98,6 +104,8 @@ public partial class MainBatteryDataContainer : DataContainerBase
 
     public bool DisplaySapDpm { get; set; }
 
+    public bool DisplayBurstReload { get; set; }
+
     public decimal GunCaliber { get; set; }
 
     public int BarrelsCount { get; set; }
@@ -150,9 +158,24 @@ public partial class MainBatteryDataContainer : DataContainerBase
         }
 
         var gun = mainBattery.Guns[0];
+        var burstModeAbility = mainBattery.BurstModeAbility;
+        var isBurstMode = modifiers.Find(modifier => modifier.AffectedProperties.Contains("MainBatteryDataContainer.BurstMode")) is not null && burstModeAbility is not null;
+        var shouldDisplayBurstModeReload = burstModeAbility is { ShotInBurst: > 1 } && isBurstMode;
 
         // Calculate main battery reload
-        decimal reload = modifiers.ApplyModifiers("MainBatteryDataContainer.Reload", gun.Reload);
+        decimal reload;
+        decimal burstReload = 1.0m;
+        if (shouldDisplayBurstModeReload)
+        {
+            reload = burstModeAbility.ReloadAfterBurst;
+            burstReload = modifiers.ApplyModifiers("MainBatteryDataContainer.Reload", burstModeAbility.ReloadDuringBurst);
+        }
+        else
+        {
+            reload = isBurstMode ? burstModeAbility.ReloadAfterBurst : gun.Reload;
+        }
+
+        reload = modifiers.ApplyModifiers("MainBatteryDataContainer.Reload", reload);
 
         decimal ammoSwitchTime = modifiers.ApplyModifiers("MainBatteryDataContainer.AmmoSwitchTime", reload * gun.AmmoSwitchCoeff);
 
@@ -175,7 +198,10 @@ public partial class MainBatteryDataContainer : DataContainerBase
         var nfi = (NumberFormatInfo)CultureInfo.InvariantCulture.NumberFormat.Clone();
         nfi.NumberGroupSeparator = "'";
 
-        var shellData = ShellDataContainer.FromShellName(gun.AmmoList, modifiers, barrelCount, true);
+        // Get burst mode ammo list
+        var burstModeAmmoList = burstModeAbility?.AlternateShells;
+        var ammoList = (burstModeAmmoList?.Length > 0 && isBurstMode) ? burstModeAmmoList : gun.AmmoList;
+        var shellData = ShellDataContainer.FromShellName(ammoList, modifiers, barrelCount, true); // TODO: need to be depended on F key if there is F key on this ship with alt ammo(s)
 
         var (horizontalDispersion, verticalDispersion) = dispersion.CalculateDispersion((double)range * 1000, dispersionModifier);
 
@@ -185,7 +211,6 @@ public partial class MainBatteryDataContainer : DataContainerBase
             Name = arrangementString.ToString(),
             TurretNames = turretNames.ToImmutableList(),
             Range = Math.Round(range, 2),
-            Reload = Math.Round(reload, 2),
             AmmoSwitchTime = Math.Round(ammoSwitchTime, 2),
             RoF = Math.Round(rateOfFire * barrelCount, 1),
             TurnTime = Math.Round(180 / traverseSpeed, 1),
@@ -206,6 +231,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
             DisplayHeDpm = shellData.Select(x => x.Type).Contains($"ArmamentType_{ShellType.HE.ShellTypeToString()}"),
             DisplayApDpm = shellData.Select(x => x.Type).Contains($"ArmamentType_{ShellType.AP.ShellTypeToString()}"),
             DisplaySapDpm = shellData.Select(x => x.Type).Contains($"ArmamentType_{ShellType.SAP.ShellTypeToString()}"),
+            DisplayBurstReload = shouldDisplayBurstModeReload,
             GunCaliber = Math.Round(gun.BarrelDiameter * 1000),
             BarrelsCount = barrelCount,
             BarrelsLayout = string.Join(" + ", barrelLayout),
@@ -233,6 +259,16 @@ public partial class MainBatteryDataContainer : DataContainerBase
             mainBatteryDataContainer.SapSalvo = Math.Round(shellDamage * barrelCount).ToString("n0", nfi);
         }
 
+        if (mainBatteryDataContainer.DisplayBurstReload)
+        {
+            mainBatteryDataContainer.BurstDuringReload = Math.Round(burstReload, 2);
+            mainBatteryDataContainer.BurstAfterReload = Math.Round(reload, 2);
+        }
+        else
+        {
+            mainBatteryDataContainer.Reload = Math.Round(reload, 2);
+        }
+
         mainBatteryDataContainer.UpdateDataElements();
         return mainBatteryDataContainer;
     }
@@ -250,5 +286,10 @@ public partial class MainBatteryDataContainer : DataContainerBase
     private bool ShouldDisplaySapDpm(object obj)
     {
         return this.DisplaySapDpm;
+    }
+
+    private bool ShouldDisplayBurstReload(object obj)
+    {
+        return this.DisplayBurstReload;
     }
 }

--- a/src/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
+++ b/src/WoWsShipBuilder.Common/Features/DataContainers/Armament/MainBatteryDataContainer.cs
@@ -159,23 +159,24 @@ public partial class MainBatteryDataContainer : DataContainerBase
 
         var gun = mainBattery.Guns[0];
         var burstModeAbility = mainBattery.BurstModeAbility;
-        var isBurstMode = modifiers.Find(modifier => modifier.AffectedProperties.Contains("MainBatteryDataContainer.BurstMode")) is not null && burstModeAbility is not null;
+        var isBurstMode = modifiers.Find(modifier => modifier.Name.Contains("BurstModeEnabled")) is not null && burstModeAbility is not null;
         var shouldDisplayBurstModeReload = burstModeAbility is { ShotInBurst: > 1 } && isBurstMode;
 
         // Calculate main battery reload
-        decimal reload;
-        decimal burstReload = 1.0m;
-        if (shouldDisplayBurstModeReload)
+        decimal reload = gun.Reload;
+        if (isBurstMode)
         {
             reload = burstModeAbility.ReloadAfterBurst;
-            burstReload = modifiers.ApplyModifiers("MainBatteryDataContainer.Reload", burstModeAbility.ReloadDuringBurst);
-        }
-        else
-        {
-            reload = isBurstMode ? burstModeAbility.ReloadAfterBurst : gun.Reload;
+            barrelCount *= burstModeAbility.ShotInBurst;
         }
 
         reload = modifiers.ApplyModifiers("MainBatteryDataContainer.Reload", reload);
+
+        decimal burstReload = 1.0m;
+        if (shouldDisplayBurstModeReload)
+        {
+            burstReload = modifiers.ApplyModifiers("MainBatteryDataContainer.Reload", burstModeAbility.ReloadDuringBurst);
+        }
 
         decimal ammoSwitchTime = modifiers.ApplyModifiers("MainBatteryDataContainer.AmmoSwitchTime", reload * gun.AmmoSwitchCoeff);
 
@@ -191,6 +192,10 @@ public partial class MainBatteryDataContainer : DataContainerBase
         var dispersion = gun.Dispersion;
 
         decimal rateOfFire = 60 / reload;
+        if (isBurstMode)
+        {
+            rateOfFire = 60 / (reload + (burstReload * (burstModeAbility.ShotInBurst - 1)));
+        }
 
         var maxRangeBw = (double)(range / 30);
         double vRadiusCoeff = (dispersion.RadiusOnMax - dispersion.RadiusOnDelim) / (maxRangeBw * (1 - dispersion.Delim));
@@ -201,7 +206,7 @@ public partial class MainBatteryDataContainer : DataContainerBase
         // Get burst mode ammo list
         var burstModeAmmoList = burstModeAbility?.AlternateShells;
         var ammoList = (burstModeAmmoList?.Length > 0 && isBurstMode) ? burstModeAmmoList : gun.AmmoList;
-        var shellData = ShellDataContainer.FromShellName(ammoList, modifiers, barrelCount, true); // TODO: need to be depended on F key if there is F key on this ship with alt ammo(s)
+        var shellData = ShellDataContainer.FromShellName(ammoList, modifiers, barrelCount, true);
 
         var (horizontalDispersion, verticalDispersion) = dispersion.CalculateDispersion((double)range * 1000, dispersionModifier);
 

--- a/src/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryDataContainer.cs
+++ b/src/WoWsShipBuilder.Common/Features/DataContainers/Armament/SecondaryBatteryDataContainer.cs
@@ -126,7 +126,7 @@ public partial class SecondaryBatteryDataContainer : DataContainerBase
             ShellDataContainer? shellData;
             try
             {
-                shellData = ShellDataContainer.FromShellName(secondaryGun.AmmoList, modifiers, barrelCount, false)[0];
+                shellData = ShellDataContainer.FromShellName(secondaryGun.AmmoList, modifiers, barrelCount, 1, false)[0];
             }
             catch (KeyNotFoundException e)
             {

--- a/src/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/ShellDataContainer.cs
+++ b/src/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/ShellDataContainer.cs
@@ -110,42 +110,42 @@ public partial class ShellDataContainer : DataContainerBase
         switch (shell.ShellType)
         {
             case ShellType.HE:
-                {
-                    overmatch = 0;
-                    showBlastPenetration = true;
+            {
+                overmatch = 0;
+                showBlastPenetration = true;
 
-                    // IFHE fire chance malus
-                    shellFireChance = modifiers.ApplyModifiers($"ShellDataContainer.FireChance.{gunType}.Multiplier", shellFireChance);
+                // IFHE fire chance malus
+                shellFireChance = modifiers.ApplyModifiers($"ShellDataContainer.FireChance.{gunType}.Multiplier", shellFireChance);
 
-                    // Victor Lima and India X-Ray signals
-                    shellFireChance = modifiers.ApplyModifiers(shell.Caliber > 0.160f ? $"ShellDataContainer.FireChance.{gunType}.Big.Additive" : $"ShellDataContainer.FireChance.{gunType}.Small.Additive", shellFireChance);
+                // Victor Lima and India X-Ray signals
+                shellFireChance = modifiers.ApplyModifiers(shell.Caliber > 0.160f ? $"ShellDataContainer.FireChance.{gunType}.Big.Additive" : $"ShellDataContainer.FireChance.{gunType}.Small.Additive", shellFireChance);
 
-                    // Demolition expert and talent
-                    shellFireChance = modifiers.ApplyModifiers($"ShellDataContainer.FireChance.{gunType}", shellFireChance);
+                // Demolition expert and talent
+                shellFireChance = modifiers.ApplyModifiers($"ShellDataContainer.FireChance.{gunType}", shellFireChance);
 
-                    // IFHE and possibly modifiers from supership abilities
-                    shellPenetration = modifiers.ApplyModifiers($"ShellDataContainer.Penetration.{gunType}", shellPenetration);
-                    goto case ShellType.SAP;
-                }
+                // IFHE and possibly modifiers from supership abilities
+                shellPenetration = modifiers.ApplyModifiers($"ShellDataContainer.Penetration.{gunType}", shellPenetration);
+                goto case ShellType.SAP;
+            }
 
             case ShellType.SAP:
-                {
-                    armingThreshold = 0;
-                    fuseTimer = 0;
-                    shellDamage = modifiers.ApplyModifiers($"ShellDataContainer.Damage.HESAP.{gunType}", shellDamage);
-                    break;
-                }
+            {
+                armingThreshold = 0;
+                fuseTimer = 0;
+                shellDamage = modifiers.ApplyModifiers($"ShellDataContainer.Damage.HESAP.{gunType}", shellDamage);
+                break;
+            }
 
             case ShellType.AP:
+            {
+                if (shell.Caliber >= 0.190f)
                 {
-                    if (shell.Caliber >= 0.190f)
-                    {
-                        shellDamage = modifiers.ApplyModifiers("ShellDataContainer.Damage.BigAp", shellDamage);
-                    }
-
-                    shellDamage = modifiers.ApplyModifiers("ShellDataContainer.Damage.Ap", shellDamage);
-                    break;
+                    shellDamage = modifiers.ApplyModifiers("ShellDataContainer.Damage.BigAp", shellDamage);
                 }
+
+                shellDamage = modifiers.ApplyModifiers("ShellDataContainer.Damage.Ap", shellDamage);
+                break;
+            }
         }
 
         decimal minRicochet = Math.Round((decimal)shell.RicochetAngle, 1);

--- a/src/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/ShellDataContainer.cs
+++ b/src/WoWsShipBuilder.Common/Features/DataContainers/Projectiles/ShellDataContainer.cs
@@ -82,14 +82,14 @@ public partial class ShellDataContainer : DataContainerBase
 
     public bool ShowBlastPenetration { get; private set; }
 
-    public static List<ShellDataContainer> FromShellName(IEnumerable<string> shellNames, ImmutableList<Modifier> modifiers, int barrelCount, bool isMainGunShell)
+    public static List<ShellDataContainer> FromShellName(IEnumerable<string> shellNames, ImmutableList<Modifier> modifiers, int barrelCount, int numberOfShots, bool isMainGunShell)
     {
-        var shells = shellNames.Select(shellName => ProcessShell(modifiers, barrelCount, isMainGunShell, shellName)).ToList();
+        var shells = shellNames.Select(shellName => ProcessShell(modifiers, barrelCount, numberOfShots, isMainGunShell, shellName)).ToList();
         shells[^1].IsLastEntry = true;
         return shells;
     }
 
-    private static ShellDataContainer ProcessShell(ImmutableList<Modifier> modifiers, int barrelCount, bool isMainGunShell, string shellName)
+    private static ShellDataContainer ProcessShell(ImmutableList<Modifier> modifiers, int barrelCount, int numberOfShots, bool isMainGunShell, string shellName)
     {
         var shell = AppData.FindProjectile<ArtilleryShell>(shellName);
 
@@ -110,48 +110,48 @@ public partial class ShellDataContainer : DataContainerBase
         switch (shell.ShellType)
         {
             case ShellType.HE:
-            {
-                overmatch = 0;
-                showBlastPenetration = true;
-
-                // IFHE fire chance malus
-                shellFireChance = modifiers.ApplyModifiers($"ShellDataContainer.FireChance.{gunType}.Multiplier", shellFireChance);
-
-                // Victor Lima and India X-Ray signals
-                shellFireChance = modifiers.ApplyModifiers(shell.Caliber > 0.160f ? $"ShellDataContainer.FireChance.{gunType}.Big.Additive" : $"ShellDataContainer.FireChance.{gunType}.Small.Additive", shellFireChance);
-
-                // Demolition expert and talent
-                shellFireChance = modifiers.ApplyModifiers($"ShellDataContainer.FireChance.{gunType}", shellFireChance);
-
-                // IFHE and possibly modifiers from supership abilities
-                shellPenetration = modifiers.ApplyModifiers($"ShellDataContainer.Penetration.{gunType}", shellPenetration);
-                goto case ShellType.SAP;
-            }
-
-            case ShellType.SAP:
-            {
-                armingThreshold = 0;
-                fuseTimer = 0;
-                shellDamage = modifiers.ApplyModifiers($"ShellDataContainer.Damage.HESAP.{gunType}", shellDamage);
-                break;
-            }
-
-            case ShellType.AP:
-            {
-                if (shell.Caliber >= 0.190f)
                 {
-                    shellDamage = modifiers.ApplyModifiers("ShellDataContainer.Damage.BigAp", shellDamage);
+                    overmatch = 0;
+                    showBlastPenetration = true;
+
+                    // IFHE fire chance malus
+                    shellFireChance = modifiers.ApplyModifiers($"ShellDataContainer.FireChance.{gunType}.Multiplier", shellFireChance);
+
+                    // Victor Lima and India X-Ray signals
+                    shellFireChance = modifiers.ApplyModifiers(shell.Caliber > 0.160f ? $"ShellDataContainer.FireChance.{gunType}.Big.Additive" : $"ShellDataContainer.FireChance.{gunType}.Small.Additive", shellFireChance);
+
+                    // Demolition expert and talent
+                    shellFireChance = modifiers.ApplyModifiers($"ShellDataContainer.FireChance.{gunType}", shellFireChance);
+
+                    // IFHE and possibly modifiers from supership abilities
+                    shellPenetration = modifiers.ApplyModifiers($"ShellDataContainer.Penetration.{gunType}", shellPenetration);
+                    goto case ShellType.SAP;
                 }
 
-                shellDamage = modifiers.ApplyModifiers("ShellDataContainer.Damage.Ap", shellDamage);
-                break;
-            }
+            case ShellType.SAP:
+                {
+                    armingThreshold = 0;
+                    fuseTimer = 0;
+                    shellDamage = modifiers.ApplyModifiers($"ShellDataContainer.Damage.HESAP.{gunType}", shellDamage);
+                    break;
+                }
+
+            case ShellType.AP:
+                {
+                    if (shell.Caliber >= 0.190f)
+                    {
+                        shellDamage = modifiers.ApplyModifiers("ShellDataContainer.Damage.BigAp", shellDamage);
+                    }
+
+                    shellDamage = modifiers.ApplyModifiers("ShellDataContainer.Damage.Ap", shellDamage);
+                    break;
+                }
         }
 
         decimal minRicochet = Math.Round((decimal)shell.RicochetAngle, 1);
         decimal maxRicochet = Math.Round((decimal)shell.AlwaysRicochetAngle, 1);
 
-        var fireChancePerSalvo = (decimal)(1 - Math.Pow((double)(1 - (shellFireChance / 100)), barrelCount));
+        var fireChancePerSalvo = (decimal)(1 - Math.Pow((double)(1 - (shellFireChance / 100)), barrelCount * numberOfShots));
 
         var splashRadius = modifiers.ApplyModifiers($"ShellDataContainer.UnderwaterSplash.{gunType}", (decimal)shell.DepthSplashRadius);
 

--- a/src/WoWsShipBuilder.Common/WoWsShipBuilder.Common.csproj
+++ b/src/WoWsShipBuilder.Common/WoWsShipBuilder.Common.csproj
@@ -24,8 +24,8 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="WoWsShipBuilder.DataStructures" Version="6.0.3" />
         <PackageReference Include="ReactiveUI" Version="22.3.1" />
+        <PackageReference Include="WoWsShipBuilder.DataStructures" Version="6.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
serveal changes about `MainBatteryDataContainer`
1. Alt ammo used in BurstMode is no longer shown. I keep the `additionalAmmoList `for additional ammo if any. Maybe WG will publish 3 ammos ships or something
2. When F Key is activated, show the alt ammos stat instead of the normal ammos.
3. Change how the reload time displaying in UI. 
    -  When ShotInBurst greater than 1 (i.e. that is not a burst mode with just ammo switching) UI will show the `ReloadDuringBurst `and the `ReloadAfterBurst`, and will apply reload modifier just like in game,
    - When there is only one shot in BurstMode, set the BusrtMode reload time directly in `Reload` attr. I did this because game just setting the reload time instead of giving a reload buff.

this need to be applied with WoWs-Builder-Team/DataConverter#36